### PR TITLE
feat: HTTP→HTTPS redirect for iem.newlevel.media

### DIFF
--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/config/config.production.yaml
+++ b/iem-mixer/config/config.production.yaml
@@ -141,6 +141,7 @@ tls: true
 https_port: 443
 tls_cert: "cert.pem"
 tls_key: "key.pem"
+https_domain: "iem.newlevel.media"
 
 # PIN codes for authentication (empty = no PIN required)
 pins: {}

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-core/src/config.rs
+++ b/iem-mixer/crates/iem-core/src/config.rs
@@ -50,6 +50,10 @@ pub struct Config {
     /// TLS private key file path (relative to config dir)
     #[serde(default = "default_tls_key")]
     pub tls_key: String,
+
+    /// Domain for HTTPS redirect (HTTP requests to this domain → HTTPS)
+    #[serde(default)]
+    pub https_domain: Option<String>,
 }
 
 fn default_reaper_url() -> String {
@@ -91,6 +95,7 @@ impl Default for Config {
             https_port: default_https_port(),
             tls_cert: default_tls_cert(),
             tls_key: default_tls_key(),
+            https_domain: None,
         }
     }
 }

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/lib.rs
+++ b/iem-mixer/crates/iem-server/src/lib.rs
@@ -167,6 +167,28 @@ pub async fn start_server(server_config: ServerConfig) -> anyhow::Result<()> {
         }
     }
 
+    // Wrap HTTP app with HTTPS redirect middleware when TLS + domain configured
+    #[cfg(feature = "tls")]
+    let app = {
+        let config = state.config.read().await;
+        if config.tls {
+            if let Some(ref domain) = config.https_domain {
+                let domain = domain.clone();
+                drop(config);
+                app.layer(axum::middleware::from_fn(move |req, next| {
+                    let domain = domain.clone();
+                    https_redirect(req, next, domain)
+                }))
+            } else {
+                drop(config);
+                app
+            }
+        } else {
+            drop(config);
+            app
+        }
+    };
+
     // HTTP server (always runs)
     let addr = SocketAddr::from(([0, 0, 0, 0], server_config.port));
     tracing::info!("Starting server on http://{}", addr);
@@ -175,6 +197,36 @@ pub async fn start_server(server_config: ServerConfig) -> anyhow::Result<()> {
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+/// Redirect HTTP requests to HTTPS when the Host header matches the configured domain.
+/// Requests via IP address (e.g., from Tauri desktop app) pass through unchanged.
+#[cfg(feature = "tls")]
+async fn https_redirect(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+    domain: String,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let host = req
+        .headers()
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
+    // Strip port from host header for comparison
+    let host_name = host.split(':').next().unwrap_or("");
+    if host_name == domain {
+        let path = req
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/");
+        let location = format!("https://{domain}{path}");
+        axum::response::Redirect::permanent(&location).into_response()
+    } else {
+        next.run(req).await
+    }
 }
 
 /// Get the local network URL for remote access

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"


### PR DESCRIPTION
## Summary
- Adds `https_domain` config field to control which domain triggers HTTP→HTTPS redirect
- HTTP requests with `Host: iem.newlevel.media` get 308 Permanent Redirect to HTTPS
- IP-based access (`http://10.77.9.231/`) passes through unchanged (Tauri desktop app)
- Version bump 1.13.0 → 1.14.0

## Test plan
- [x] `curl -sv http://iem.newlevel.media/` returns 308 redirect to `https://iem.newlevel.media/`
- [x] `curl -sf http://10.77.9.231/` returns 200 (no redirect)
- [x] CI passes all jobs (lint, tests, build, e2e, deploy)
- [ ] Phone: type `iem.newlevel.media` → auto-redirects to HTTPS with green padlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)