### PR TITLE
fix: solo crash recovery + header indicator (v1.137.0 + v1.138.0) (#155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.137.0 (2026-04-09)
+
+- **Fix**: Solo no longer leaves tracks muted after PWA crash/disconnect (#155)
+- **Feature**: Server-managed solo state persists across reconnects — solo stays active until explicitly turned off
+
 ### v1.136.0 (2026-04-09)
 
 - **Feature**: Backup/restore system — automatic scheduled backups at 13:00 and 21:00, engineer-only restore UI in Settings modal with preview and estimated time

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.136.0 (2026-04-09)
+
+- **Feature**: Backup/restore system — automatic scheduled backups at 13:00 and 21:00, engineer-only restore UI in Settings modal with preview and estimated time
+- **Feature**: Track-level mute state (global mute, stems mute) now included in backups and restored correctly
+- **Fix**: Backup stores LINEAR volumes directly (no dB conversion) — prevents zeroing sends on restore
+- **Fix**: Restore skips unchanged values (sends, volumes, EQ, limiter, customizations, PINs) — faster restores
+- **Fix**: Estimated restore time includes 30s base read overhead for accurate predictions
+
 ### v1.130.0 (2026-04-04)
 
 - **Feature**: Member profile photos — upload from Settings modal, displayed as circular avatars on landing page (#16)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.138.0 (2026-04-10)
+
+- **Feature**: Solo indicator in header — when solo is active, a prominent yellow "SOLO ✕" button replaces the version display in the header, visible on every tab. One click clears solo from any tab.
+- **UI**: Header compacted — smaller back button and vertical LAN/WAN indicator to save horizontal space
+
 ### v1.137.0 (2026-04-09)
 
 - **Fix**: Solo no longer leaves tracks muted after PWA crash/disconnect (#155)

--- a/docs/superpowers/plans/2026-04-09-solo-server-side-state.md
+++ b/docs/superpowers/plans/2026-04-09-solo-server-side-state.md
@@ -1,0 +1,680 @@
+# Server-Side Solo State — Implementation Plan (#155)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix solo leaving everything muted after PWA crash by moving solo muting to server-side with pre-solo state persistence.
+
+**Architecture:** Solo muting moves from UI→individual SetMute commands to server-side batch muting on SetSolo. Server saves pre-solo mute states and restores them on unsolo or disconnect recovery. Solo state persists across WebSocket disconnects until explicitly turned off.
+
+**Tech Stack:** Rust (Axum server), Leptos (WASM UI), Playwright (E2E tests)
+
+**Spec:** `docs/superpowers/specs/2026-04-09-solo-server-side-state-design.md`
+
+---
+
+## File Map
+
+### Server changes
+- `iem-mixer/crates/iem-server/src/lib.rs:161` — Add `pre_solo_mutes` field to `MixerCache`
+- `iem-mixer/crates/iem-server/src/proxy.rs:1346-1364` — Rewrite SetSolo handler (move into `apply_command_to_cache`)
+- `iem-mixer/crates/iem-server/src/proxy.rs:1440-1448` — Remove solo cleanup from disconnect handler
+- `iem-mixer/crates/iem-server/src/proxy.rs:1594` — Add SetSolo arm to `apply_command_to_cache`
+
+### UI changes
+- `iem-mixer/iem-ui/src/pages/mixer.rs:2391-2499` — Remove SetMute calls from solo click handler, keep only SetSolo
+
+### E2E tests
+- `iem-mixer/e2e/tests/live/mixer.spec.ts:2134-2241` — Update existing solo tests, add crash recovery test
+
+### Version bump
+- 5 Cargo.toml + 1 tauri.conf.json: 1.136.0 → 1.137.0
+
+---
+
+## Task 1: Version Bump (1.136.0 → 1.137.0)
+
+- [ ] **Step 1: Bump all version files**
+
+```bash
+sed -i 's/version = "1.136.0"/version = "1.137.0"/' \
+  iem-mixer/crates/iem-core/Cargo.toml \
+  iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml \
+  iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml
+sed -i 's/"version": "1.136.0"/"version": "1.137.0"/' iem-mixer/src-tauri/tauri.conf.json
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -c '1.137.0' iem-mixer/crates/iem-core/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+# Both should return 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/crates/iem-core/Cargo.toml iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+git commit -m "chore: bump version to 1.137.0"
+```
+
+---
+
+## Task 2: Add `pre_solo_mutes` to MixerCache
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/lib.rs:161`
+
+- [ ] **Step 1: Add field after `solo_states`**
+
+In `lib.rs`, after line 161 (`pub solo_states: HashMap<String, Vec<usize>>`), add:
+
+```rust
+    /// Pre-solo mute states per member — saved when solo activates, restored on unsolo
+    /// (member_id -> (track_index, send_index, was_muted))
+    pub pre_solo_mutes: HashMap<String, Vec<(usize, usize, bool)>>,
+```
+
+We store `(track_index, send_index, was_muted)` tuples so the restore can send REAPER commands without needing to recalculate send indices.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add iem-mixer/crates/iem-server/src/lib.rs
+git commit -m "feat: add pre_solo_mutes field to MixerCache (#155)"
+```
+
+---
+
+## Task 3: Move SetSolo handling into `apply_command_to_cache`
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs`
+
+This is the core change. We remove the early `SetSolo` handler (lines 1346-1364) and add a new match arm in `apply_command_to_cache` (after line 1656) that handles solo with REAPER mute commands.
+
+- [ ] **Step 1: Remove the early SetSolo handler**
+
+Remove the block at lines 1346-1364:
+
+```rust
+// REMOVE THIS ENTIRE BLOCK:
+// Handle solo state updates (no REAPER command — solo is UI-only sync)
+if let ClientMsg::SetSolo { ref soloed } = cmd {
+    {
+        let mut cache = state.mixer_cache.write().await;
+        if soloed.is_empty() {
+            cache.solo_states.remove(&member_id);
+        } else {
+            cache.solo_states
+                .insert(member_id.clone(), soloed.clone());
+        }
+    }
+    let _ = state.event_tx.send((
+        member_id.clone(),
+        ServerMsg::SoloUpdate {
+            soloed: soloed.clone(),
+        },
+    ));
+    continue;
+}
+```
+
+- [ ] **Step 2: Add SetSolo validation in the match block**
+
+In the `match cmd` validation block inside `apply_command_to_cache` (around line 1658), add a new arm after `SetMute`:
+
+```rust
+        iem_core::ClientMsg::SetSolo { ref soloed } => {
+            for ti in soloed {
+                if !is_valid_track(*ti) {
+                    return Err(format!("solo track_index {} out of range", ti));
+                }
+            }
+        }
+```
+
+- [ ] **Step 3: Add SetSolo dispatch arm**
+
+After the `SetMute` dispatch arm (around line 1789), add the new `SetSolo` arm. This is the core logic:
+
+```rust
+        iem_core::ClientMsg::SetSolo { ref soloed } => {
+            let soloed_set: std::collections::HashSet<usize> = soloed.iter().copied().collect();
+            let mut cache = state.mixer_cache.write().await;
+            let current_solo = cache.solo_states.get(member_id).cloned().unwrap_or_default();
+            let had_solo = !current_solo.is_empty();
+            let wants_solo = !soloed_set.is_empty();
+
+            // Collect mute commands to send to REAPER
+            let mut reaper_urls: Vec<String> = Vec::new();
+            let mut events: Vec<iem_core::ServerMsg> = Vec::new();
+
+            if wants_solo && !had_solo {
+                // ENTERING SOLO: save current mute states, then mute everything except soloed
+                let mut saved = Vec::new();
+                if let Some(channels) = cache.member_states.get(member_id) {
+                    for ch in channels {
+                        if let Ok(si) = send_index_for(ch.track_index) {
+                            saved.push((ch.track_index, si, ch.muted));
+                        }
+                    }
+                }
+                cache.pre_solo_mutes.insert(member_id.to_string(), saved);
+
+                // Mute/unmute channels
+                if let Some(channels) = cache.member_states.get_mut(member_id) {
+                    for ch in channels.iter_mut() {
+                        let should_mute = !soloed_set.contains(&ch.track_index);
+                        if ch.muted != should_mute {
+                            ch.muted = should_mute;
+                            if let Ok(si) = send_index_for(ch.track_index) {
+                                let mute_val: u8 = if should_mute { 1 } else { 0 };
+                                reaper_urls.push(reaper_api::set_send_mute(
+                                    &reaper_url, ch.track_index, si, mute_val,
+                                ));
+                            }
+                            events.push(iem_core::ServerMsg::ChannelUpdate {
+                                track_index: ch.track_index,
+                                level_db: ch.level_db,
+                                muted: ch.muted,
+                                pan: ch.pan,
+                            });
+                        }
+                    }
+                }
+            } else if wants_solo && had_solo {
+                // SWITCHING SOLO: keep pre_solo_mutes, update mute to new target
+                if let Some(channels) = cache.member_states.get_mut(member_id) {
+                    for ch in channels.iter_mut() {
+                        let should_mute = !soloed_set.contains(&ch.track_index);
+                        if ch.muted != should_mute {
+                            ch.muted = should_mute;
+                            if let Ok(si) = send_index_for(ch.track_index) {
+                                let mute_val: u8 = if should_mute { 1 } else { 0 };
+                                reaper_urls.push(reaper_api::set_send_mute(
+                                    &reaper_url, ch.track_index, si, mute_val,
+                                ));
+                            }
+                            events.push(iem_core::ServerMsg::ChannelUpdate {
+                                track_index: ch.track_index,
+                                level_db: ch.level_db,
+                                muted: ch.muted,
+                                pan: ch.pan,
+                            });
+                        }
+                    }
+                }
+            } else if !wants_solo && had_solo {
+                // EXITING SOLO: restore pre-solo mute states
+                if let Some(saved) = cache.pre_solo_mutes.remove(member_id) {
+                    if let Some(channels) = cache.member_states.get_mut(member_id) {
+                        for (track_idx, send_idx, was_muted) in &saved {
+                            if let Some(ch) = channels.iter_mut().find(|c| c.track_index == *track_idx) {
+                                if ch.muted != *was_muted {
+                                    ch.muted = *was_muted;
+                                    let mute_val: u8 = if *was_muted { 1 } else { 0 };
+                                    reaper_urls.push(reaper_api::set_send_mute(
+                                        &reaper_url, *track_idx, *send_idx, mute_val,
+                                    ));
+                                    events.push(iem_core::ServerMsg::ChannelUpdate {
+                                        track_index: *track_idx,
+                                        level_db: ch.level_db,
+                                        muted: ch.muted,
+                                        pan: ch.pan,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Update solo state
+            if wants_solo {
+                cache.solo_states.insert(member_id.to_string(), soloed.clone());
+            } else {
+                cache.solo_states.remove(member_id);
+            }
+
+            // Mark command timestamps for all affected tracks
+            let now = std::time::Instant::now();
+            if let Some(channels) = cache.member_states.get(member_id) {
+                for ch in channels {
+                    cache.command_timestamps.insert(
+                        (member_id.to_string(), ch.track_index),
+                        now,
+                    );
+                }
+            }
+
+            drop(cache);
+
+            // Send all REAPER commands
+            for url in &reaper_urls {
+                let _ = state.http_client.get(url).send().await;
+            }
+
+            // Broadcast solo update
+            let _ = state.event_tx.send((
+                member_id.to_string(),
+                ServerMsg::SoloUpdate { soloed: soloed.clone() },
+            ));
+
+            // Broadcast channel updates for changed mutes
+            for event in events {
+                let _ = state.event_tx.send((member_id.to_string(), event));
+            }
+
+            // Return a dummy URL (no single REAPER command — already sent above)
+            return Ok(("".to_string(), None));
+        }
+```
+
+- [ ] **Step 4: Handle the empty URL return**
+
+The caller of `apply_command_to_cache` sends the returned URL to REAPER. Since SetSolo already sent its own REAPER commands, it returns an empty string. Check the caller at line 1366-1380 to make sure an empty URL is handled:
+
+```rust
+match apply_command_to_cache(&state, &member_id, &cmd).await {
+    Ok((url, broadcast)) => {
+        // ...
+        if !url.is_empty() {
+            match state.http_client.get(&url).send().await {
+```
+
+If the caller already checks `!url.is_empty()`, no change needed. If not, add the check.
+
+Read lines 1366-1395 to verify and add the guard if needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add iem-mixer/crates/iem-server/src/proxy.rs
+git commit -m "feat: server-side solo muting with pre-solo state persistence (#155)"
+```
+
+---
+
+## Task 4: Remove solo cleanup from disconnect handler
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs:1439-1448`
+
+- [ ] **Step 1: Remove `solo_states.remove()` from disconnect cleanup**
+
+At line 1446, remove this line:
+
+```rust
+// REMOVE THIS LINE:
+cache.solo_states.remove(&member_id);
+```
+
+The surrounding code stays — we still remove `active_members` and `member_states` on last disconnect.
+
+**Important:** Also do NOT remove `pre_solo_mutes` on disconnect. Solo state persists until explicit unsolo.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add iem-mixer/crates/iem-server/src/proxy.rs
+git commit -m "fix: solo state persists across WebSocket disconnects (#155)"
+```
+
+---
+
+## Task 5: Remove SetMute calls from UI solo handler
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/src/pages/mixer.rs:2391-2499`
+
+The UI should only send `SetSolo` — the server handles muting. Keep local `set_channels.update()` for optimistic UI rendering.
+
+- [ ] **Step 1: Simplify the solo click handler**
+
+Replace the entire `on_solo_click` closure (lines 2391-2499) with:
+
+```rust
+                    let on_solo_click = move |_| {
+                        if !connected.get() {
+                            return;
+                        }
+
+                        let all_channels = channels.get();
+                        let current_soloed = soloed.get();
+                        let is_currently_soloed = current_soloed.contains(&track_idx);
+
+                        if is_currently_soloed {
+                            // UN-SOLO this track
+                            let mut new_soloed = current_soloed.clone();
+                            new_soloed.remove(&track_idx);
+                            if let Some(partner) = partner_idx {
+                                new_soloed.remove(&partner);
+                            }
+
+                            if new_soloed.is_empty() {
+                                // Restore pre-solo mutes (optimistic UI)
+                                let saved = pre_solo_mutes.get();
+                                set_channels.update(|chs| {
+                                    for c in chs.iter_mut() {
+                                        let should_be_muted = saved.get(&c.track_index).copied().unwrap_or(false);
+                                        c.muted = should_be_muted;
+                                    }
+                                });
+                                set_pre_solo_mutes.set(HashMap::new());
+                            } else {
+                                // Partial unsolo — mute the desoloed track(s)
+                                set_channels.update(|chs| {
+                                    if let Some(ch) = chs.iter_mut().find(|c| c.track_index == track_idx) {
+                                        ch.muted = true;
+                                    }
+                                    if let Some(partner) = partner_idx {
+                                        if let Some(ch) = chs.iter_mut().find(|c| c.track_index == partner) {
+                                            ch.muted = true;
+                                        }
+                                    }
+                                });
+                            }
+
+                            let soloed_vec: Vec<usize> = new_soloed.iter().copied().collect();
+                            set_soloed.set(new_soloed);
+                            ws_send(ws, &iem_core::ClientMsg::SetSolo { soloed: soloed_vec });
+                        } else {
+                            // SOLO this track
+                            let was_empty = current_soloed.is_empty();
+
+                            if was_empty {
+                                // Save pre-solo mutes for optimistic UI restore
+                                let mut saved_mutes = HashMap::new();
+                                for ch in &all_channels {
+                                    saved_mutes.insert(ch.track_index, ch.muted);
+                                }
+                                set_pre_solo_mutes.set(saved_mutes);
+                            }
+
+                            // Optimistic UI: mute everything except solo target
+                            set_channels.update(|chs| {
+                                for c in chs.iter_mut() {
+                                    c.muted = c.track_index != track_idx
+                                        && partner_idx != Some(c.track_index);
+                                }
+                            });
+
+                            // Build soloed set — exclusive (only new track + partner)
+                            let mut new_soloed = std::collections::HashSet::new();
+                            new_soloed.insert(track_idx);
+                            if let Some(partner) = partner_idx {
+                                new_soloed.insert(partner);
+                            }
+                            let soloed_vec: Vec<usize> = new_soloed.iter().copied().collect();
+                            set_soloed.set(new_soloed);
+                            ws_send(ws, &iem_core::ClientMsg::SetSolo { soloed: soloed_vec });
+                        }
+                    };
+```
+
+Key differences from old code:
+- **No `ws_send(ws, &iem_core::ClientMsg::SetMute { ... })` calls** — server handles muting
+- **Keep `set_channels.update()`** — optimistic UI rendering
+- **Keep `pre_solo_mutes`** — UI-side copy for optimistic restore display
+- **Only `ws_send` is `SetSolo`** — single message to server
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add iem-mixer/iem-ui/src/pages/mixer.rs
+git commit -m "refactor: UI sends only SetSolo — server handles muting (#155)"
+```
+
+---
+
+## Task 6: Update E2E solo tests
+
+**Files:**
+- Modify: `iem-mixer/e2e/tests/live/mixer.spec.ts`
+
+The existing solo tests should still pass since the behavior is the same (solo activates, exclusive mode works). We need to add a new test for crash recovery.
+
+- [ ] **Step 1: Add solo crash recovery test**
+
+After the "solo is exclusive" test (line 2241), add:
+
+```typescript
+  test("solo persists after disconnect and reconnect", async ({
+    browser,
+  }) => {
+    // This tests the crash recovery: solo on → disconnect → reconnect → solo still active
+    const ctx1 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+
+    await page1.goto("/");
+    await loginAs(page1, "petronela");
+    await page1.goto("/petronela");
+    await waitForMixer(page1);
+
+    await expect(page1.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    const micsTab = page1.locator(".category-tab.mics");
+    if ((await micsTab.count()) > 0) await micsTab.click();
+    await page1.waitForTimeout(500);
+
+    const soloBtn = page1.locator(".solo-btn").first();
+    expect(await soloBtn.count()).toBeGreaterThan(0);
+
+    // Activate solo
+    await soloBtn.click({ force: true });
+    await expect(soloBtn).toHaveClass(/on/, { timeout: 3000 });
+
+    // Close the page (simulates crash/disconnect)
+    await ctx1.close();
+
+    // Wait for server to process disconnect
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // Reconnect with a new context (simulates reopening PWA)
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+
+    await page2.goto("/");
+    await loginAs(page2, "petronela");
+    await page2.goto("/petronela");
+    await waitForMixer(page2);
+
+    await expect(page2.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    const micsTab2 = page2.locator(".category-tab.mics");
+    if ((await micsTab2.count()) > 0) await micsTab2.click();
+    await page2.waitForTimeout(500);
+
+    // Solo should still be active after reconnect
+    const soloBtn2 = page2.locator(".solo-btn").first();
+    await expect(soloBtn2).toHaveClass(/on/, { timeout: 5000 });
+
+    // Unsolo to clean up — should restore pre-solo mutes
+    await soloBtn2.click({ force: true });
+    await expect(soloBtn2).toHaveClass(/off/, { timeout: 3000 });
+
+    await ctx2.close();
+  });
+```
+
+- [ ] **Step 2: Add solo unsolo restores mutes test**
+
+After the crash recovery test, add a test that verifies mute states are properly restored:
+
+```typescript
+  test("unsolo restores original mute states", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto("/");
+    await loginAs(page, "petronela");
+    await page.goto("/petronela");
+    await waitForMixer(page);
+
+    await expect(page.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    const micsTab = page.locator(".category-tab.mics");
+    if ((await micsTab.count()) > 0) await micsTab.click();
+    await page.waitForTimeout(500);
+
+    const channels = page.locator(".channel");
+    const count = await channels.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Record initial mute states
+    const initialMutes: boolean[] = [];
+    for (let i = 0; i < count; i++) {
+      const cls = (await channels.nth(i).getAttribute("class")) || "";
+      initialMutes.push(cls.includes("muted"));
+    }
+
+    // Solo first channel
+    const soloBtn = page.locator(".solo-btn").first();
+    await soloBtn.click({ force: true });
+    await expect(soloBtn).toHaveClass(/on/, { timeout: 3000 });
+    await page.waitForTimeout(300);
+
+    // Verify non-solo channels are muted
+    for (let i = 1; i < count; i++) {
+      await expect(channels.nth(i)).toHaveClass(/muted/, { timeout: 2000 });
+    }
+
+    // Unsolo
+    await soloBtn.click({ force: true });
+    await expect(soloBtn).toHaveClass(/off/, { timeout: 3000 });
+    await page.waitForTimeout(500);
+
+    // Verify mute states match initial
+    for (let i = 0; i < count; i++) {
+      const cls = (await channels.nth(i).getAttribute("class")) || "";
+      const nowMuted = cls.includes("muted");
+      expect(nowMuted).toBe(initialMutes[i]);
+    }
+
+    await ctx.close();
+  });
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/e2e/tests/live/mixer.spec.ts
+git commit -m "test: add solo crash recovery and mute restore E2E tests (#155)"
+```
+
+---
+
+## Task 7: Handle empty URL return from apply_command_to_cache
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs`
+
+- [ ] **Step 1: Read the caller and add empty URL guard**
+
+Read lines 1366-1395 of `proxy.rs` where `apply_command_to_cache` result is used. If the caller sends the URL to REAPER unconditionally, wrap the REAPER HTTP call in an `if !url.is_empty()` check.
+
+The SetSolo arm returns `Ok(("".to_string(), None))` since it already sent its own REAPER commands internally.
+
+- [ ] **Step 2: Commit (if changes needed)**
+
+```bash
+git add iem-mixer/crates/iem-server/src/proxy.rs
+git commit -m "fix: skip REAPER request for empty URL (SetSolo handles internally) (#155)"
+```
+
+---
+
+## Task 8: Format check + Push + Monitor CI
+
+- [ ] **Step 1: Run local format check**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+cd iem-mixer/iem-ui && cargo fmt --all --check
+```
+
+Fix any formatting issues with `cargo fmt --all`.
+
+- [ ] **Step 2: Push and monitor**
+
+```bash
+git push origin dev
+gh run list --limit 3
+```
+
+- [ ] **Step 3: Monitor CI until ALL jobs reach terminal state**
+
+Poll with `gh run view <run-id>` every 5 minutes. All 9 jobs must pass including deploy and post-deploy E2E.
+
+- [ ] **Step 4: If CI fails, investigate with `gh run view <id> --log-failed` and fix all issues in ONE commit**
+
+---
+
+## Task 9: Update changelog + Create PR
+
+- [ ] **Step 1: Add changelog entry to README.md**
+
+```markdown
+### v1.137.0 (2026-04-09)
+- **Fix**: Solo no longer leaves tracks muted after PWA crash/disconnect (#155)
+- **Feature**: Server-managed solo state persists across reconnects
+```
+
+- [ ] **Step 2: Commit and push**
+
+```bash
+git add README.md
+git commit -m "docs: add changelog for v1.137.0 server-side solo state (#155)"
+git push origin dev
+```
+
+- [ ] **Step 3: Create PR**
+
+```bash
+gh pr create --title "fix: solo crash recovery — server-side mute state (#155)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Solo muting moved from UI to server — prevents orphaned mutes on crash
+- Pre-solo mute states saved server-side, restored on unsolo
+- Solo persists across WebSocket disconnects until explicitly turned off
+- Fixes #155
+
+## Test plan
+- [ ] Solo on → unsolo → mute states restored correctly
+- [ ] Solo on → kill PWA → reopen → solo still active → unsolo → mutes restored
+- [ ] Solo exclusive mode still works (solo A, then solo B replaces A)
+- [ ] Multi-tab: solo syncs across tabs
+- [ ] Post-deploy E2E passes 171+ tests
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Monitor PR CI until green, verify mergeable**
+
+---
+
+## Task Dependencies
+
+```
+Task 1 (version bump)                  ──┐
+Task 2 (pre_solo_mutes field)          ──┤── Sequential (each builds on previous)
+Task 3 (SetSolo server logic)          ──┤
+Task 4 (remove disconnect cleanup)     ──┤
+Task 5 (UI simplification)            ──┤
+Task 6 (E2E tests)                     ──┤
+Task 7 (empty URL guard)              ──┘
+         │
+         ▼
+Task 8 (format + push + CI)
+         │
+         ▼
+Task 9 (changelog + PR)
+```
+
+Tasks 1-7 are sequential (each modifies files that depend on previous changes). Tasks 8-9 are post-implementation.

--- a/docs/superpowers/plans/2026-04-10-solo-indicator-header.md
+++ b/docs/superpowers/plans/2026-04-10-solo-indicator-header.md
@@ -1,0 +1,566 @@
+# Solo Indicator in Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a prominent "Clear Solo" button in the mixer header that appears when solo is active on any channel, visible across all tabs, allowing one-click unsolo from any category tab.
+
+**Architecture:** UI-only change (server logic unchanged). Header layout reclaims space by shrinking back button and making LAN/WAN indicator vertical. When `soloed` signal is non-empty, the header-version display is replaced by a prominent yellow "SOLO ✕" button that sends `SetSolo { soloed: [] }` on click. The existing server-side exit-solo logic (v1.137.0) handles the restore.
+
+**Tech Stack:** Rust (Leptos WASM frontend), CSS, Playwright E2E tests
+
+**Spec:** `docs/superpowers/specs/2026-04-10-solo-indicator-header-design.md`
+
+---
+
+## File Map
+
+### UI code
+- `iem-mixer/iem-ui/src/pages/mixer.rs:1182-1225` — Header markup: shrink back button container, add conditional render for SOLO button vs version display
+- `iem-mixer/iem-ui/style.css` — CSS: compact back button, vertical network indicator, new `.header-solo-btn` with pulse animation
+
+### E2E tests
+- `iem-mixer/e2e/tests/live/mixer.spec.ts` — Add 2 new tests for header solo button (single-tab clear, cross-tab visibility)
+
+### Version bump
+- 5 Cargo.toml + 1 tauri.conf.json: 1.137.0 → 1.138.0
+
+### Changelog
+- `README.md` — Add v1.138.0 entry
+
+---
+
+## Task 1: Version Bump (1.137.0 → 1.138.0)
+
+- [ ] **Step 1: Bump all version files**
+
+```bash
+sed -i 's/version = "1.137.0"/version = "1.138.0"/' \
+  iem-mixer/crates/iem-core/Cargo.toml \
+  iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml \
+  iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml
+sed -i 's/"version": "1.137.0"/"version": "1.138.0"/' iem-mixer/src-tauri/tauri.conf.json
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -c '1.138.0' iem-mixer/crates/iem-core/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+# Both should return 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/crates/iem-core/Cargo.toml iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+git commit -m "chore: bump version to 1.138.0"
+```
+
+---
+
+## Task 2: CSS — Compact back button and vertical network indicator
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/style.css`
+
+- [ ] **Step 1: Shrink `.mixer-header .back-btn`**
+
+Find the existing rule at line ~91:
+```css
+.mixer-header .back-btn {
+  width: 40px;
+  height: 40px;
+  ...
+}
+```
+
+Replace the `width` and `height` to save horizontal space:
+```css
+.mixer-header .back-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0;
+}
+```
+
+Keep all other existing properties (hover, etc.) unchanged.
+
+- [ ] **Step 2: Make `.network-indicator` vertical**
+
+Find the existing rule at line ~1847:
+```css
+.network-indicator {
+  font-size: 0.6em;
+  font-weight: 700;
+  padding: 2px 6px;
+  ...
+}
+```
+
+Replace with:
+```css
+.network-indicator {
+  font-size: 0.5em;
+  font-weight: 700;
+  padding: 2px 3px;
+  border-radius: 4px;
+  letter-spacing: 0;
+  flex-shrink: 0;
+  margin-right: 4px;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  line-height: 1.1;
+  max-width: 14px;
+}
+```
+
+Keep `.network-indicator.local` and `.network-indicator.remote` unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/iem-ui/style.css
+git commit -m "style: shrink back button and verticalize network indicator for header space (#155)"
+```
+
+---
+
+## Task 3: CSS — Add `.header-solo-btn` styles
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/style.css`
+
+- [ ] **Step 1: Add solo button styles after `.header-version-date`**
+
+Find the existing block at line ~120:
+```css
+.header-version-date {
+  font-size: 0.55em;
+  color: #fff;
+  white-space: nowrap;
+}
+```
+
+Add AFTER it:
+```css
+/* Solo active indicator in header (replaces version when solo is active) */
+.header-solo-btn {
+  background: #f59e0b;
+  color: #fff;
+  border: none;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-right: 8px;
+  animation: pulse-solo 1.5s ease-in-out infinite;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.header-solo-btn:hover {
+  background: #d97706;
+}
+
+.header-solo-btn:active {
+  background: #b45309;
+}
+
+.header-solo-btn .solo-close {
+  font-size: 1rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+@keyframes pulse-solo {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(245, 158, 11, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-solo-btn {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add iem-mixer/iem-ui/style.css
+git commit -m "style: add header solo button styles with pulse animation (#155)"
+```
+
+---
+
+## Task 4: UI — Conditional render of solo button in header
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/src/pages/mixer.rs`
+
+- [ ] **Step 1: Read current header code to confirm line numbers**
+
+Read lines 1182-1225 of `iem-mixer/iem-ui/src/pages/mixer.rs` to confirm the header structure before editing.
+
+- [ ] **Step 2: Replace `.header-version` block with conditional render**
+
+Find this block (around lines 1194-1197):
+```rust
+                <div class="header-version">
+                    <span class="header-version-number">{iem_core::version_label()}</span>
+                    <span class="header-version-date">{iem_core::build_datetime()}</span>
+                </div>
+```
+
+Replace with:
+```rust
+                <Show
+                    when=move || !soloed.get().is_empty()
+                    fallback=|| view! {
+                        <div class="header-version">
+                            <span class="header-version-number">{iem_core::version_label()}</span>
+                            <span class="header-version-date">{iem_core::build_datetime()}</span>
+                        </div>
+                    }
+                >
+                    <button
+                        class="header-solo-btn"
+                        aria-label="Clear solo"
+                        on:click=move |_| {
+                            if !connected.get() {
+                                return;
+                            }
+                            // Optimistic UI: clear soloed signal locally and restore pre-solo mutes
+                            let saved = pre_solo_mutes.get();
+                            set_channels.update(|chs| {
+                                for c in chs.iter_mut() {
+                                    let should_be_muted = saved.get(&c.track_index).copied().unwrap_or(false);
+                                    c.muted = should_be_muted;
+                                }
+                            });
+                            set_pre_solo_mutes.set(HashMap::new());
+                            set_soloed.set(std::collections::HashSet::new());
+                            // Send empty SetSolo to server — triggers server-side unsolo + restore
+                            ws_send(ws, &iem_core::ClientMsg::SetSolo { soloed: vec![] });
+                        }
+                    >
+                        "SOLO"
+                        <span class="solo-close">"\u{2715}"</span>
+                    </button>
+                </Show>
+```
+
+**Notes for implementer:**
+- The `view!` macro is already imported (used elsewhere in mixer.rs)
+- `Show` component from leptos is already used elsewhere in this file (see line 1201)
+- `soloed`, `set_soloed`, `connected`, `pre_solo_mutes`, `set_pre_solo_mutes`, `set_channels`, `ws` are all in scope inside the `view!` macro (captured from the component params)
+- `HashMap` is already imported (used elsewhere)
+- `ws_send` helper already exists and is used (see `on_solo_click` handler)
+- The `"\u{2715}"` is the multiplication X symbol (✕)
+
+- [ ] **Step 3: Format**
+
+```bash
+cd iem-mixer/iem-ui && cargo fmt --all
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iem-mixer/iem-ui/src/pages/mixer.rs
+git commit -m "feat: add solo clear button in header when solo is active (#155)"
+```
+
+---
+
+## Task 5: E2E test — Header solo button shows and clears solo (single tab)
+
+**Files:**
+- Modify: `iem-mixer/e2e/tests/live/mixer.spec.ts`
+
+- [ ] **Step 1: Add test inside `test.describe("Solo sync", ...)` block**
+
+Find the "unsolo restores original mute states" test (around line 2317). After its closing `});`, and BEFORE the `});` that closes `test.describe("Solo sync", ...)`, add:
+
+```typescript
+  test("header solo button clears solo from any tab", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto("/");
+    await loginAs(page, "petronela");
+    await page.goto("/petronela");
+    await waitForMixer(page);
+
+    await expect(page.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    // Switch to Mics tab to find a solo button
+    const micsTab = page.locator(".category-tab.mics");
+    if ((await micsTab.count()) > 0) await micsTab.click();
+    await page.waitForTimeout(500);
+
+    // Verify header initially shows version (no solo active)
+    await expect(page.locator(".header-version")).toBeVisible();
+    await expect(page.locator(".header-solo-btn")).toHaveCount(0);
+
+    // Activate solo
+    const soloBtn = page.locator(".solo-btn").first();
+    await soloBtn.click({ force: true });
+    await page.waitForTimeout(500);
+    await expect(soloBtn).toHaveClass(/on/, { timeout: 5000 });
+
+    // Header should now show SOLO button
+    await expect(page.locator(".header-solo-btn")).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".header-version")).toHaveCount(0);
+
+    // Click header SOLO button to clear
+    await page.locator(".header-solo-btn").click({ force: true });
+    await page.waitForTimeout(500);
+
+    // Header should revert to version display
+    await expect(page.locator(".header-version")).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".header-solo-btn")).toHaveCount(0);
+
+    // Channel solo button should be off
+    await expect(soloBtn).toHaveClass(/off/, { timeout: 3000 });
+
+    await ctx.close();
+  });
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add iem-mixer/e2e/tests/live/mixer.spec.ts
+git commit -m "test: header solo button shows and clears solo (#155)"
+```
+
+---
+
+## Task 6: E2E test — Cross-tab header solo button visibility
+
+**Files:**
+- Modify: `iem-mixer/e2e/tests/live/mixer.spec.ts`
+
+- [ ] **Step 1: Add second test after Task 5's test, before `});` of describe block**
+
+```typescript
+  test("header solo button appears on second tab when first tab solos", async ({
+    browser,
+  }) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    await page1.goto("/");
+    await page2.goto("/");
+    await loginAs(page1, "petronela");
+    await page1.goto("/petronela");
+    await loginAs(page2, "petronela");
+    await page2.goto("/petronela");
+
+    await waitForMixer(page1);
+    await waitForMixer(page2);
+
+    await expect(page1.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+    await expect(page2.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    // Switch both to Mics tab
+    const micsTab1 = page1.locator(".category-tab.mics");
+    if ((await micsTab1.count()) > 0) await micsTab1.click();
+    const micsTab2 = page2.locator(".category-tab.mics");
+    if ((await micsTab2.count()) > 0) await micsTab2.click();
+    await page1.waitForTimeout(500);
+    await page2.waitForTimeout(500);
+
+    // Both headers show version initially
+    await expect(page1.locator(".header-version")).toBeVisible();
+    await expect(page2.locator(".header-version")).toBeVisible();
+
+    // Activate solo on tab1
+    const soloBtn1 = page1.locator(".solo-btn").first();
+    await soloBtn1.click({ force: true });
+    await page1.waitForTimeout(500);
+    await expect(soloBtn1).toHaveClass(/on/, { timeout: 5000 });
+
+    // Tab1 header shows SOLO button
+    await expect(page1.locator(".header-solo-btn")).toBeVisible({ timeout: 3000 });
+
+    // Tab2 should ALSO show SOLO button (sync via SoloUpdate broadcast)
+    await expect(page2.locator(".header-solo-btn")).toBeVisible({ timeout: 5000 });
+
+    // Clear solo from tab2
+    await page2.locator(".header-solo-btn").click({ force: true });
+    await page2.waitForTimeout(500);
+
+    // Both tabs revert to version display
+    await expect(page2.locator(".header-version")).toBeVisible({ timeout: 3000 });
+    await expect(page1.locator(".header-version")).toBeVisible({ timeout: 5000 });
+
+    // Both tabs' solo buttons are off
+    await expect(soloBtn1).toHaveClass(/off/, { timeout: 3000 });
+
+    await ctx1.close();
+    await ctx2.close();
+  });
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add iem-mixer/e2e/tests/live/mixer.spec.ts
+git commit -m "test: cross-tab header solo button visibility and clear (#155)"
+```
+
+---
+
+## Task 7: Format check + Push + Monitor CI
+
+- [ ] **Step 1: Run format check**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+cd iem-mixer/iem-ui && cargo fmt --all --check
+```
+
+Fix any issues with `cargo fmt --all` if needed.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor CI**
+
+```bash
+gh run list --branch dev --limit 3
+```
+
+Poll `gh run view <run-id> --json status,conclusion,jobs` until all jobs reach terminal state. All 9 jobs must be green (Test Integrity, Lint, VBAN, WASM, Tests, E2E, Tauri, Deploy). Post-deploy E2E must pass all tests (including the 2 new header solo tests).
+
+- [ ] **Step 4: If CI fails, investigate with `gh run view <id> --log-failed` and fix all issues in ONE commit**
+
+Common expected issues:
+- Clippy warnings on new Rust code (collapsible_if, unused imports)
+- Format issues (cargo fmt)
+- E2E test timing issues on production system — may need waitForTimeout tweaks
+- The `Show` component usage — verify the view! macro syntax is correct in Leptos
+
+---
+
+## Task 8: Update changelog + PR update
+
+- [ ] **Step 1: Add changelog entry to README.md**
+
+Read `README.md` to find the `## Changelog` section. Add after `### v1.137.0` (at the top of the changelog):
+
+```markdown
+### v1.138.0 (2026-04-10)
+
+- **Feature**: Solo indicator in header — when solo is active, a prominent "SOLO ✕" button replaces the version display in the header, visible on every tab. Click it to clear solo from anywhere.
+- **UI**: Header compacted — smaller back button and vertical LAN/WAN indicator to save horizontal space
+```
+
+- [ ] **Step 2: Commit and push**
+
+```bash
+git add README.md
+git commit -m "docs: add changelog for v1.138.0 solo indicator in header (#155)"
+git push origin dev
+```
+
+- [ ] **Step 3: Update PR #158 title/description**
+
+Since PR #158 is still open and includes these new commits, update its description to mention the additional v1.138.0 feature:
+
+```bash
+gh pr edit 158 --title "fix: solo crash recovery + header indicator (v1.137.0 + v1.138.0) (#155)" --body "$(cat <<'EOF'
+## Summary
+**v1.137.0 — Solo crash recovery:**
+- Solo muting moved from UI to server — prevents orphaned mutes on PWA crash
+- Pre-solo mute states saved server-side, restored on unsolo
+- Solo persists across WebSocket disconnects until explicitly turned off
+
+**v1.138.0 — Solo indicator in header:**
+- Yellow "SOLO ✕" button appears in header when solo is active (replaces version display)
+- Visible on every category tab — solves visibility problem from v1.137.0 persistence
+- One click clears solo from any tab
+- Header compacted: smaller back button, vertical LAN/WAN indicator
+
+Fixes #155
+
+## Test plan
+- [x] Solo on → unsolo → mute states restored correctly
+- [x] Solo on → kill PWA → reopen → solo still active → unsolo → mutes restored
+- [x] Solo exclusive mode still works (solo A, then solo B replaces A)
+- [x] Multi-tab: solo syncs across tabs
+- [x] Header SOLO button clears solo from any tab
+- [x] Cross-tab: solo on tab1 → tab2 header shows SOLO button
+- [x] Post-deploy E2E: all tests pass on live iem.lan
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Verify PR is mergeable after CI completes**
+
+```bash
+gh api repos/zbynekdrlik/reaperiem/pulls/158 --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Should return `mergeable: true, mergeable_state: "clean"`.
+
+---
+
+## Task Dependencies
+
+```
+Task 1 (version bump)           ──┐
+Task 2 (CSS compact header)     ──┤
+Task 3 (CSS solo button)        ──┤── Sequential
+Task 4 (UI conditional render)  ──┤
+Task 5 (E2E single-tab)         ──┤
+Task 6 (E2E cross-tab)          ──┘
+         │
+         ▼
+Task 7 (format + push + CI)
+         │
+         ▼
+Task 8 (changelog + PR update)
+```
+
+Tasks 2-6 depend on Task 1 (version bump must be first). Task 4 depends on Tasks 2-3 (CSS must exist before UI can reference it, although order doesn't strictly matter for CSS-only builds). Tasks 5-6 depend on Task 4 (tests require the UI to work). Tasks 7-8 run after all implementation is done.
+
+---
+
+## Verification checklist
+
+After CI is green:
+
+1. All 9 CI jobs pass on dev branch
+2. Post-deploy E2E passes including the 2 new header solo tests
+3. `.header-solo-btn` visible in DOM when solo is active (verify manually via http://10.77.9.231/)
+4. Header reverts to version display when solo is cleared
+5. PR #158 includes both v1.137.0 and v1.138.0 work
+6. PR mergeable: clean

--- a/docs/superpowers/specs/2026-04-09-solo-server-side-state-design.md
+++ b/docs/superpowers/specs/2026-04-09-solo-server-side-state-design.md
@@ -1,0 +1,129 @@
+# Fix: Solo Leaves Everything Muted After PWA Crash (#155)
+
+## Problem
+
+When a band member activates solo and their PWA crashes/hangs/is killed, tracks remain muted in REAPER with no recovery path. The member must manually unmute tens of tracks.
+
+**Root cause:** Solo state is managed client-side. The UI sends individual `SetMute` commands to mute/unmute tracks, while `SetSolo` only syncs the solo indicator. When the last WebSocket disconnects, `solo_states` is cleared from server memory, and on reconnect the client doesn't know solo was active — REAPER tracks stay muted.
+
+## Design: Server-Managed Solo
+
+Move solo muting entirely to the server. The client sends `SetSolo` only; the server handles all REAPER mute commands and persists pre-solo state for crash recovery.
+
+### New Server State
+
+Add to `MixerCache` in `lib.rs`:
+
+```rust
+/// Pre-solo mute states per member — saved when solo activates
+/// (member_id -> track_index -> was_muted_before_solo)
+pub pre_solo_mutes: HashMap<String, HashMap<usize, bool>>,
+```
+
+### SetSolo Handler Changes (`proxy.rs`)
+
+When server receives `ClientMsg::SetSolo { soloed }`:
+
+**Case 1: Entering solo** (no current solo, `soloed` non-empty)
+1. Read current mute states from `member_states` cache → save to `pre_solo_mutes`
+2. For each channel in `member_states`:
+   - If `track_index` NOT in `soloed` set → send `SET/TRACK/{t}/SEND/{si}/MUTE/1` to REAPER, update cache `muted = true`
+   - If `track_index` IN `soloed` set → send `SET/TRACK/{t}/SEND/{si}/MUTE/0` to REAPER, update cache `muted = false`
+3. Store `solo_states[member] = soloed`
+4. Broadcast `SoloUpdate` + `ChannelUpdate` for changed channels
+
+**Case 2: Switching solo** (current solo non-empty, new `soloed` different)
+1. Keep existing `pre_solo_mutes` (from original solo entry)
+2. For each channel: apply same mute logic as Case 1 based on new soloed set
+3. Update `solo_states[member]`
+4. Broadcast updates
+
+**Case 3: Exiting solo** (`soloed` empty, current solo non-empty)
+1. Read `pre_solo_mutes[member]`
+2. For each channel: restore mute state from saved pre_solo_mutes → send REAPER commands
+3. Clear `solo_states[member]` and `pre_solo_mutes[member]`
+4. Broadcast `SoloUpdate { soloed: [] }` + `ChannelUpdate` for changed channels
+
+### Disconnect Behavior Change (`proxy.rs`)
+
+**Do NOT clear `solo_states` or `pre_solo_mutes` on disconnect.** Remove only `member_states` and `active_members` as before. Solo persists until explicit unsolo.
+
+```rust
+// BEFORE (line 1446):
+cache.solo_states.remove(&member_id);
+
+// AFTER: remove this line — solo survives disconnects
+```
+
+### Reconnect Behavior (already works)
+
+On connect, server already sends `SoloUpdate` from cached `solo_states` (lines 1036-1046). After this fix, the state will still be there after a disconnect, so the reconnecting client will receive the active solo state and render correctly.
+
+### UI Changes (`mixer.rs`)
+
+In the solo click handler (`on_solo_click`):
+- **Remove** all `ws_send(ws, &iem_core::ClientMsg::SetMute { ... })` calls from solo logic
+- **Keep** local `set_channels.update(...)` for immediate visual feedback (optimistic UI)
+- **Keep** `ws_send(ws, &iem_core::ClientMsg::SetSolo { ... })` — this is the only WS message sent
+- **Keep** `pre_solo_mutes` local signal for UI display (but it's now just for optimistic rendering; server is source of truth)
+
+The server broadcasts `ChannelUpdate` for each changed channel, which the UI already handles for cross-tab sync.
+
+### SoloUpdate Handler (UI)
+
+On receiving `SoloUpdate` from server:
+- **Keep** existing logic that updates `soloed` signal and channel muted display
+- The server now also sends `ChannelUpdate` for each muted/unmuted track, so the UI gets explicit mute state from the server
+
+### send_index_for
+
+The `send_index_for` closure is defined inside `apply_command_to_cache` (line 1645), NOT in the SetSolo handler scope (line 1347). Two approaches:
+
+**Chosen approach:** Move SetSolo handling INTO `apply_command_to_cache` instead of the early `continue` block. This gives access to `send_index_for`, `member_index`, `reaper_url`, `input_count`, and `mix_members`. Add `SetSolo` as a new match arm in the command dispatch at line 1658.
+
+The early handler (line 1347) is removed. SetSolo flows through the same validation and dispatch path as SetMute/SetLevel.
+
+### REAPER Command Helper
+
+Extract a helper for sending mute commands for all channels during solo transitions:
+
+```rust
+async fn apply_solo_mutes(
+    http_client: &reqwest::Client,
+    reaper_url: &str,
+    channels: &mut [Channel],
+    soloed: &HashSet<usize>,
+    member_index: usize,
+    mix_members: &[(usize, Option<usize>)],
+) -> Vec<(usize, bool)> {
+    // For each channel, compute should_mute = !soloed.contains(track_index)
+    // Send REAPER set_send_mute for changed channels only
+    // Update channel.muted in cache
+    // Returns vec of (track_index, new_muted) for ChannelUpdate broadcast
+}
+```
+
+### What This Fixes
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| PWA crash during solo | Tracks muted forever, no recovery | Reconnect shows solo active, unsolo restores |
+| Kill and reopen PWA | Solo state lost, mutes orphaned | Solo state persisted, displayed on reconnect |
+| Multiple tabs, one crashes | Solo state inconsistent | Server manages state, all tabs sync |
+| Normal solo on/off | Works (UI manages mutes) | Works (server manages mutes) |
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `iem-mixer/crates/iem-server/src/lib.rs` | Add `pre_solo_mutes` to `MixerCache` |
+| `iem-mixer/crates/iem-server/src/proxy.rs` | Server-side solo muting in SetSolo handler, remove solo cleanup from disconnect |
+| `iem-mixer/iem-ui/src/pages/mixer.rs` | Remove SetMute calls from solo click handler |
+| `iem-mixer/e2e/tests/live/mixer.spec.ts` | Update solo E2E tests to verify server-managed behavior |
+
+### Testing
+
+1. **Unit test**: `SetSolo` handler saves pre_solo_mutes, sends correct REAPER commands
+2. **E2E test**: Solo on → verify tracks muted in REAPER → unsolo → verify tracks restored
+3. **E2E test**: Solo on → disconnect WS → reconnect → verify solo still active → unsolo → verify restore
+4. **Live verification**: Solo on → kill PWA → reopen → see solo active → click unsolo → all tracks back to normal

--- a/docs/superpowers/specs/2026-04-10-solo-indicator-header-design.md
+++ b/docs/superpowers/specs/2026-04-10-solo-indicator-header-design.md
@@ -1,0 +1,179 @@
+# Solo Indicator and Clear Button in Header
+
+## Problem
+
+After v1.137.0 solo now persists across tabs and WebSocket disconnects. This introduces a new usability gap:
+
+- When a user opens the PWA and a previous solo is still active, they see channels muted with no indication WHY
+- Solo can be activated on one tab but there's no visual cue on other tabs (beyond the solo button itself, which is only visible on the relevant channel tab — Mics, Stems, etc.)
+- To unsolo, the user must find the soloed channel (which may be on a different category tab) and click its solo button
+- No quick way to "clear all solo" without hunting for the source channel
+
+## Goal
+
+Make solo state globally visible in the header (always on screen regardless of category tab) and give the user a one-click way to clear solo from any tab.
+
+## Constraints (User feedback)
+
+- **No new bar** — cannot add a banner that consumes vertical space above the mixer
+- **Reuse header space** — shrink existing elements to make room
+- Version/date stays visible normally, replaced by Clear Solo button only when solo is active
+
+## Design
+
+### Header Layout Changes
+
+**Current header (before):**
+```
+[ ← ] [ MemberName ] [ v1.137.0 / 2026-04-10 ] [ ⚙ ] [LAN] [●]
+```
+
+**When solo is NOT active (after — compacted):**
+```
+[←][ MemberName ] [ v1.137.0 / 2026-04-10 ] [ ⚙ ] [L] [●]
+                                                     [A]
+                                                     [N]
+```
+
+**When solo IS active:**
+```
+[←][ MemberName ] [ 🟡 SOLO ✕ ] [ ⚙ ] [L] [●]
+                                        [A]
+                                        [N]
+```
+
+### Component Changes
+
+1. **Back button (`.back-btn`)** — shrink padding
+   - Smaller horizontal/vertical padding (`4px 6px` or similar)
+   - Still tappable on touch devices (min 32px touch target)
+   - Icon stays the same `←`
+
+2. **Network indicator (`.network-indicator`)** — vertical text
+   - CSS: `writing-mode: vertical-rl; transform: rotate(180deg);` (or similar)
+   - Font size: ~9-10px
+   - Letters stack vertically: L over A over N
+   - Saves ~30-40px horizontal space
+
+3. **Solo button (new, conditional)** — in place of `.header-version`
+   - Conditional render: `when soloed.get().is_empty() → .header-version, else → .header-solo-btn`
+   - Label: "SOLO ✕" (text + close icon)
+   - Background: yellow or orange (`#f59e0b` or similar) — high visibility
+   - Bold text, white foreground
+   - Subtle pulse animation to draw attention (`@keyframes pulse-solo`)
+   - Same height as version display (no layout shift)
+   - Click handler sends `ClientMsg::SetSolo { soloed: vec![] }` via WebSocket
+   - Also clears local `pre_solo_mutes` signal (already handled in SoloUpdate receiver)
+
+### Data Flow
+
+```
+User clicks "SOLO ✕" in header
+  ↓
+ws_send(ClientMsg::SetSolo { soloed: vec![] })
+  ↓
+Server apply_command_to_cache processes SetSolo with empty soloed
+  → had_solo && !wants_solo branch (EXITING SOLO)
+  → reads pre_solo_mutes from cache
+  → sends REAPER set_send_mute commands to restore original mute states
+  → clears solo_states and pre_solo_mutes for member
+  → broadcasts SoloUpdate { soloed: [] }
+  → broadcasts ChannelUpdate for each changed channel
+  ↓
+All member's tabs receive:
+  - SoloUpdate → set_soloed.set(empty) → header reverts from SOLO btn to version display
+  - ChannelUpdate per track → set_channels updates mute states → channels visually unmute
+```
+
+### Why This Works
+
+- Server-side SetSolo handler (v1.137.0) already handles empty `soloed` vec as "exit solo and restore"
+- `soloed` signal is already shared across the mixer component
+- Header is rendered at the top level (`mixer-header`), always visible regardless of category tab
+- No new server-side state or messages needed
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `iem-mixer/iem-ui/src/pages/mixer.rs` | Header conditional render: SOLO button when `!soloed.is_empty()`, else version display. Shrink back button markup. |
+| `iem-mixer/iem-ui/styles/...` (or inline) | CSS: shrunk `.back-btn`, vertical `.network-indicator`, new `.header-solo-btn` with pulse animation |
+| `iem-mixer/e2e/tests/live/mixer.spec.ts` | New E2E: solo on channel → verify header shows SOLO btn → click → verify header reverts + channels unmuted. Cross-tab: solo on tab1 → verify tab2 header shows SOLO btn. |
+
+### CSS Details
+
+```css
+/* Compacted back button */
+.back-btn {
+  padding: 4px 8px;  /* was larger */
+  font-size: 1.2rem; /* slightly smaller */
+}
+
+/* Vertical network indicator */
+.network-indicator {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 9px;
+  font-weight: bold;
+  padding: 2px 4px;
+  line-height: 1.1;
+}
+
+/* Solo button in header (replaces version when active) */
+.header-solo-btn {
+  background: #f59e0b;  /* amber */
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-weight: bold;
+  font-size: 0.9rem;
+  cursor: pointer;
+  animation: pulse-solo 1.5s ease-in-out infinite;
+}
+
+.header-solo-btn:hover {
+  background: #d97706;
+}
+
+@keyframes pulse-solo {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.6); }
+  50% { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0); }
+}
+```
+
+### Testing
+
+1. **E2E: single-tab clear solo from header**
+   - Login, solo a channel
+   - Verify header shows "SOLO ✕" button (yellow)
+   - Click header SOLO button
+   - Verify header reverts to version display
+   - Verify soloed channel's solo button returns to "off"
+   - Verify other channels are no longer muted
+
+2. **E2E: cross-tab clear from non-source tab**
+   - Open two tabs (ctx1, ctx2) for same member
+   - On tab1: solo a channel
+   - On tab2: verify header shows SOLO button (received via SoloUpdate broadcast)
+   - On tab2: click header SOLO button
+   - Verify both tabs' headers revert to version
+   - Verify both tabs' channels are unmuted
+
+3. **E2E: clear from different category tab**
+   - Solo a channel on Mics tab
+   - Switch to Stems (or another) tab
+   - Verify SOLO button still visible in header
+   - Click it → verify unsolo works
+
+### Accessibility
+
+- SOLO button has `aria-label="Clear solo"` for screen readers
+- Pulse animation respects `prefers-reduced-motion: reduce` — disables pulse
+
+### What Stays the Same
+
+- Server-side solo state management (v1.137.0 logic unchanged)
+- Channel-level solo buttons (still functional)
+- `SetSolo` / `SoloUpdate` / `ChannelUpdate` WebSocket messages
+- Pre-solo mute restore behavior

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.136.0"
+version = "1.137.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.137.0"
+version = "1.138.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.137.0"
+version = "1.138.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.136.0"
+version = "1.137.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.137.0"
+version = "1.138.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.136.0"
+version = "1.137.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/lib.rs
+++ b/iem-mixer/crates/iem-server/src/lib.rs
@@ -159,6 +159,9 @@ pub struct MixerCache {
     pub snapshot_last_date: HashMap<String, String>,
     /// Solo state per member — transient, in-memory only (member_id -> soloed track indices)
     pub solo_states: HashMap<String, Vec<usize>>,
+    /// Pre-solo mute states per member — saved when solo activates, restored on unsolo
+    /// (member_id -> (track_index, send_index, was_muted))
+    pub pre_solo_mutes: HashMap<String, Vec<(usize, usize, bool)>>,
     /// Stems-bus track indices per member (member_id -> 1-based track index)
     pub stems_bus_indices: HashMap<String, usize>,
     /// Last known stems-bus volume per member (member_id -> state)

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1921,29 +1921,27 @@ async fn apply_command_to_cache(
                 }
             } else if !wants_solo && had_solo {
                 // EXITING SOLO: restore pre-solo mute states
-                if let Some(saved) = cache.pre_solo_mutes.remove(member_id) {
-                    if let Some(channels) = cache.member_states.get_mut(member_id) {
-                        for (track_idx, send_idx, was_muted) in &saved {
-                            if let Some(ch) =
-                                channels.iter_mut().find(|c| c.track_index == *track_idx)
-                            {
-                                if ch.muted != *was_muted {
-                                    ch.muted = *was_muted;
-                                    let mute_val: u8 = if *was_muted { 1 } else { 0 };
-                                    reaper_urls.push(reaper_api::set_send_mute(
-                                        &reaper_url,
-                                        *track_idx,
-                                        *send_idx,
-                                        mute_val,
-                                    ));
-                                    events.push(iem_core::ServerMsg::ChannelUpdate {
-                                        track_index: *track_idx,
-                                        level_db: ch.level_db,
-                                        muted: ch.muted,
-                                        pan: ch.pan,
-                                    });
-                                }
-                            }
+                if let Some(saved) = cache.pre_solo_mutes.remove(member_id)
+                    && let Some(channels) = cache.member_states.get_mut(member_id)
+                {
+                    for (track_idx, send_idx, was_muted) in &saved {
+                        if let Some(ch) = channels.iter_mut().find(|c| c.track_index == *track_idx)
+                            && ch.muted != *was_muted
+                        {
+                            ch.muted = *was_muted;
+                            let mute_val: u8 = if *was_muted { 1 } else { 0 };
+                            reaper_urls.push(reaper_api::set_send_mute(
+                                &reaper_url,
+                                *track_idx,
+                                *send_idx,
+                                mute_val,
+                            ));
+                            events.push(iem_core::ServerMsg::ChannelUpdate {
+                                track_index: *track_idx,
+                                level_db: ch.level_db,
+                                muted: ch.muted,
+                                pan: ch.pan,
+                            });
                         }
                     }
                 }

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1343,38 +1343,20 @@ async fn handle_ws(
                                 continue;
                             }
 
-                            // Handle solo state updates (no REAPER command — solo is UI-only sync)
-                            if let ClientMsg::SetSolo { ref soloed } = cmd {
-                                {
-                                    let mut cache = state.mixer_cache.write().await;
-                                    if soloed.is_empty() {
-                                        cache.solo_states.remove(&member_id);
-                                    } else {
-                                        cache.solo_states
-                                            .insert(member_id.clone(), soloed.clone());
-                                    }
-                                }
-                                let _ = state.event_tx.send((
-                                    member_id.clone(),
-                                    ServerMsg::SoloUpdate {
-                                        soloed: soloed.clone(),
-                                    },
-                                ));
-                                continue;
-                            }
-
                             match apply_command_to_cache(&state, &member_id, &cmd).await {
                                 Ok((url, broadcast)) => {
                                     // Broadcast to other clients of same member for cross-device sync
                                     if let Some(event) = broadcast {
                                         let _ = state.event_tx.send((member_id.clone(), event));
                                     }
-                                    send_to_reaper(
-                                        state.http_client.clone(),
-                                        url,
-                                        member_id.clone(),
-                                        cmd,
-                                    );
+                                    if !url.is_empty() {
+                                        send_to_reaper(
+                                            state.http_client.clone(),
+                                            url,
+                                            member_id.clone(),
+                                            cmd,
+                                        );
+                                    }
                                 }
                                 Err(e) => {
                                     tracing::warn!(
@@ -1697,9 +1679,12 @@ async fn apply_command_to_cache(
             // Handled in WS handler before apply_command_to_cache is called
             return Err("UpdateCustomization should not reach apply_command_to_cache".to_string());
         }
-        iem_core::ClientMsg::SetSolo { .. } => {
-            // Handled in WS handler before apply_command_to_cache is called
-            return Err("SetSolo should not reach apply_command_to_cache".to_string());
+        iem_core::ClientMsg::SetSolo { ref soloed } => {
+            for ti in soloed {
+                if !is_valid_track(*ti) {
+                    return Err(format!("solo track_index {} out of range", ti));
+                }
+            }
         }
         iem_core::ClientMsg::CallEngineer => {
             // Handled in WS handler before apply_command_to_cache is called
@@ -1861,8 +1846,151 @@ async fn apply_command_to_cache(
         iem_core::ClientMsg::UpdateCustomization { .. } => {
             unreachable!("UpdateCustomization handled before apply_command_to_cache")
         }
-        iem_core::ClientMsg::SetSolo { .. } => {
-            unreachable!("SetSolo handled before apply_command_to_cache")
+        iem_core::ClientMsg::SetSolo { ref soloed } => {
+            let soloed_set: std::collections::HashSet<usize> = soloed.iter().copied().collect();
+            let mut cache = state.mixer_cache.write().await;
+            let current_solo = cache
+                .solo_states
+                .get(member_id)
+                .cloned()
+                .unwrap_or_default();
+            let had_solo = !current_solo.is_empty();
+            let wants_solo = !soloed_set.is_empty();
+
+            let mut reaper_urls: Vec<String> = Vec::new();
+            let mut events: Vec<iem_core::ServerMsg> = Vec::new();
+
+            if wants_solo && !had_solo {
+                // ENTERING SOLO: save current mute states, then mute everything except soloed
+                let mut saved = Vec::new();
+                if let Some(channels) = cache.member_states.get(member_id) {
+                    for ch in channels {
+                        if let Ok(si) = send_index_for(ch.track_index) {
+                            saved.push((ch.track_index, si, ch.muted));
+                        }
+                    }
+                }
+                cache.pre_solo_mutes.insert(member_id.to_string(), saved);
+
+                if let Some(channels) = cache.member_states.get_mut(member_id) {
+                    for ch in channels.iter_mut() {
+                        let should_mute = !soloed_set.contains(&ch.track_index);
+                        if ch.muted != should_mute {
+                            ch.muted = should_mute;
+                            if let Ok(si) = send_index_for(ch.track_index) {
+                                let mute_val: u8 = if should_mute { 1 } else { 0 };
+                                reaper_urls.push(reaper_api::set_send_mute(
+                                    &reaper_url,
+                                    ch.track_index,
+                                    si,
+                                    mute_val,
+                                ));
+                            }
+                            events.push(iem_core::ServerMsg::ChannelUpdate {
+                                track_index: ch.track_index,
+                                level_db: ch.level_db,
+                                muted: ch.muted,
+                                pan: ch.pan,
+                            });
+                        }
+                    }
+                }
+            } else if wants_solo && had_solo {
+                // SWITCHING SOLO: keep pre_solo_mutes, update mutes to new target
+                if let Some(channels) = cache.member_states.get_mut(member_id) {
+                    for ch in channels.iter_mut() {
+                        let should_mute = !soloed_set.contains(&ch.track_index);
+                        if ch.muted != should_mute {
+                            ch.muted = should_mute;
+                            if let Ok(si) = send_index_for(ch.track_index) {
+                                let mute_val: u8 = if should_mute { 1 } else { 0 };
+                                reaper_urls.push(reaper_api::set_send_mute(
+                                    &reaper_url,
+                                    ch.track_index,
+                                    si,
+                                    mute_val,
+                                ));
+                            }
+                            events.push(iem_core::ServerMsg::ChannelUpdate {
+                                track_index: ch.track_index,
+                                level_db: ch.level_db,
+                                muted: ch.muted,
+                                pan: ch.pan,
+                            });
+                        }
+                    }
+                }
+            } else if !wants_solo && had_solo {
+                // EXITING SOLO: restore pre-solo mute states
+                if let Some(saved) = cache.pre_solo_mutes.remove(member_id) {
+                    if let Some(channels) = cache.member_states.get_mut(member_id) {
+                        for (track_idx, send_idx, was_muted) in &saved {
+                            if let Some(ch) =
+                                channels.iter_mut().find(|c| c.track_index == *track_idx)
+                            {
+                                if ch.muted != *was_muted {
+                                    ch.muted = *was_muted;
+                                    let mute_val: u8 = if *was_muted { 1 } else { 0 };
+                                    reaper_urls.push(reaper_api::set_send_mute(
+                                        &reaper_url,
+                                        *track_idx,
+                                        *send_idx,
+                                        mute_val,
+                                    ));
+                                    events.push(iem_core::ServerMsg::ChannelUpdate {
+                                        track_index: *track_idx,
+                                        level_db: ch.level_db,
+                                        muted: ch.muted,
+                                        pan: ch.pan,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Update solo state
+            if wants_solo {
+                cache
+                    .solo_states
+                    .insert(member_id.to_string(), soloed.clone());
+            } else {
+                cache.solo_states.remove(member_id);
+            }
+
+            // Mark command timestamps for all affected tracks (suppresses poller echo)
+            let now = std::time::Instant::now();
+            if let Some(channels) = cache.member_states.get(member_id) {
+                for ch in channels {
+                    cache
+                        .command_timestamps
+                        .insert((member_id.to_string(), ch.track_index), now);
+                }
+            }
+
+            drop(cache);
+
+            // Send all REAPER commands
+            for url in &reaper_urls {
+                let _ = state.http_client.get(url).send().await;
+            }
+
+            // Broadcast solo state update
+            let _ = state.event_tx.send((
+                member_id.to_string(),
+                iem_core::ServerMsg::SoloUpdate {
+                    soloed: soloed.clone(),
+                },
+            ));
+
+            // Broadcast channel updates for changed mutes
+            for event in events {
+                let _ = state.event_tx.send((member_id.to_string(), event));
+            }
+
+            // Return empty URL — REAPER commands already sent above
+            return Ok(("".to_string(), None));
         }
         iem_core::ClientMsg::CallEngineer => {
             unreachable!("CallEngineer handled before apply_command_to_cache")

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1678,7 +1678,7 @@ async fn apply_command_to_cache(
             // Handled in WS handler before apply_command_to_cache is called
             return Err("UpdateCustomization should not reach apply_command_to_cache".to_string());
         }
-        iem_core::ClientMsg::SetSolo { ref soloed } => {
+        iem_core::ClientMsg::SetSolo { soloed } => {
             for ti in soloed {
                 if !is_valid_track(*ti) {
                     return Err(format!("solo track_index {} out of range", ti));
@@ -1845,7 +1845,7 @@ async fn apply_command_to_cache(
         iem_core::ClientMsg::UpdateCustomization { .. } => {
             unreachable!("UpdateCustomization handled before apply_command_to_cache")
         }
-        iem_core::ClientMsg::SetSolo { ref soloed } => {
+        iem_core::ClientMsg::SetSolo { soloed } => {
             let soloed_set: std::collections::HashSet<usize> = soloed.iter().copied().collect();
             let mut cache = state.mixer_cache.write().await;
             let current_solo = cache
@@ -1960,12 +1960,15 @@ async fn apply_command_to_cache(
 
             // Mark command timestamps for all affected tracks (suppresses poller echo)
             let now = std::time::Instant::now();
-            if let Some(channels) = cache.member_states.get(member_id) {
-                for ch in channels {
-                    cache
-                        .command_timestamps
-                        .insert((member_id.to_string(), ch.track_index), now);
-                }
+            let track_indices: Vec<usize> = cache
+                .member_states
+                .get(member_id)
+                .map(|chs| chs.iter().map(|c| c.track_index).collect())
+                .unwrap_or_default();
+            for ti in track_indices {
+                cache
+                    .command_timestamps
+                    .insert((member_id.to_string(), ti), now);
             }
 
             drop(cache);

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1425,7 +1425,6 @@ async fn handle_ws(
         if *count == 0 {
             cache.active_members.remove(&member_id);
             cache.member_states.remove(&member_id);
-            cache.solo_states.remove(&member_id);
         }
     }
 }

--- a/iem-mixer/e2e/tests/live/mixer.spec.ts
+++ b/iem-mixer/e2e/tests/live/mixer.spec.ts
@@ -2409,4 +2409,64 @@ test.describe("Solo sync", () => {
 
     await ctx.close();
   });
+
+  test("header solo button appears on second tab when first tab solos", async ({
+    browser,
+  }) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    await page1.goto("/");
+    await page2.goto("/");
+    await loginAs(page1, "petronela");
+    await page1.goto("/petronela");
+    await loginAs(page2, "petronela");
+    await page2.goto("/petronela");
+
+    await waitForMixer(page1);
+    await waitForMixer(page2);
+
+    await expect(page1.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+    await expect(page2.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    // Switch both to Mics tab
+    const micsTab1 = page1.locator(".category-tab.mics");
+    if ((await micsTab1.count()) > 0) await micsTab1.click();
+    const micsTab2 = page2.locator(".category-tab.mics");
+    if ((await micsTab2.count()) > 0) await micsTab2.click();
+    await page1.waitForTimeout(500);
+    await page2.waitForTimeout(500);
+
+    // Both headers show version initially
+    await expect(page1.locator(".header-version")).toBeVisible();
+    await expect(page2.locator(".header-version")).toBeVisible();
+
+    // Activate solo on tab1
+    const soloBtn1 = page1.locator(".solo-btn").first();
+    await soloBtn1.click({ force: true });
+    await page1.waitForTimeout(500);
+    await expect(soloBtn1).toHaveClass(/on/, { timeout: 5000 });
+
+    // Tab1 header shows SOLO button
+    await expect(page1.locator(".header-solo-btn")).toBeVisible({ timeout: 3000 });
+
+    // Tab2 should ALSO show SOLO button (sync via SoloUpdate broadcast)
+    await expect(page2.locator(".header-solo-btn")).toBeVisible({ timeout: 5000 });
+
+    // Clear solo from tab2
+    await page2.locator(".header-solo-btn").click({ force: true });
+    await page2.waitForTimeout(500);
+
+    // Both tabs revert to version display
+    await expect(page2.locator(".header-version")).toBeVisible({ timeout: 3000 });
+    await expect(page1.locator(".header-version")).toBeVisible({ timeout: 5000 });
+
+    // Both tabs' solo buttons are off
+    await expect(soloBtn1).toHaveClass(/off/, { timeout: 3000 });
+
+    await ctx1.close();
+    await ctx2.close();
+  });
 });

--- a/iem-mixer/e2e/tests/live/mixer.spec.ts
+++ b/iem-mixer/e2e/tests/live/mixer.spec.ts
@@ -2167,13 +2167,18 @@ test.describe("Solo sync", () => {
     expect(await soloBtn1.count()).toBeGreaterThan(0);
 
     await soloBtn1.click({ force: true });
+    await page1.waitForTimeout(300);
 
     // Wait for solo to activate on page1 (requires working WS + server)
-    await expect(soloBtn1).toHaveClass(/on/, { timeout: 3000 });
+    await expect(soloBtn1).toHaveClass(/on/, { timeout: 5000 });
 
     // Verify page2 sees the solo state
     const soloBtn2 = page2.locator(".solo-btn").first();
-    await expect(soloBtn2).toHaveClass(/on/, { timeout: 3000 });
+    await expect(soloBtn2).toHaveClass(/on/, { timeout: 5000 });
+
+    // Clean up: unsolo to restore state
+    await soloBtn1.click({ force: true });
+    await expect(soloBtn1).toHaveClass(/off/, { timeout: 3000 });
 
     await ctx1.close();
     await ctx2.close();

--- a/iem-mixer/e2e/tests/live/mixer.spec.ts
+++ b/iem-mixer/e2e/tests/live/mixer.spec.ts
@@ -2365,4 +2365,48 @@ test.describe("Solo sync", () => {
 
     await ctx.close();
   });
+
+  test("header solo button clears solo from any tab", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto("/");
+    await loginAs(page, "petronela");
+    await page.goto("/petronela");
+    await waitForMixer(page);
+
+    await expect(page.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    // Switch to Mics tab to find a solo button
+    const micsTab = page.locator(".category-tab.mics");
+    if ((await micsTab.count()) > 0) await micsTab.click();
+    await page.waitForTimeout(500);
+
+    // Verify header initially shows version (no solo active)
+    await expect(page.locator(".header-version")).toBeVisible();
+    await expect(page.locator(".header-solo-btn")).toHaveCount(0);
+
+    // Activate solo
+    const soloBtn = page.locator(".solo-btn").first();
+    await soloBtn.click({ force: true });
+    await page.waitForTimeout(500);
+    await expect(soloBtn).toHaveClass(/on/, { timeout: 5000 });
+
+    // Header should now show SOLO button
+    await expect(page.locator(".header-solo-btn")).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".header-version")).toHaveCount(0);
+
+    // Click header SOLO button to clear
+    await page.locator(".header-solo-btn").click({ force: true });
+    await page.waitForTimeout(500);
+
+    // Header should revert to version display
+    await expect(page.locator(".header-version")).toBeVisible({ timeout: 3000 });
+    await expect(page.locator(".header-solo-btn")).toHaveCount(0);
+
+    // Channel solo button should be off
+    await expect(soloBtn).toHaveClass(/off/, { timeout: 3000 });
+
+    await ctx.close();
+  });
 });

--- a/iem-mixer/e2e/tests/live/mixer.spec.ts
+++ b/iem-mixer/e2e/tests/live/mixer.spec.ts
@@ -2239,4 +2239,112 @@ test.describe("Solo sync", () => {
 
     await ctx.close();
   });
+
+  test("solo persists after disconnect and reconnect", async ({
+    browser,
+  }) => {
+    const ctx1 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+
+    await page1.goto("/");
+    await loginAs(page1, "petronela");
+    await page1.goto("/petronela");
+    await waitForMixer(page1);
+
+    await expect(page1.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    const micsTab = page1.locator(".category-tab.mics");
+    if ((await micsTab.count()) > 0) await micsTab.click();
+    await page1.waitForTimeout(500);
+
+    const soloBtn = page1.locator(".solo-btn").first();
+    expect(await soloBtn.count()).toBeGreaterThan(0);
+
+    // Activate solo
+    await soloBtn.click({ force: true });
+    await expect(soloBtn).toHaveClass(/on/, { timeout: 3000 });
+
+    // Close the page (simulates crash/disconnect)
+    await ctx1.close();
+
+    // Wait for server to process disconnect
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // Reconnect with a new context (simulates reopening PWA)
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+
+    await page2.goto("/");
+    await loginAs(page2, "petronela");
+    await page2.goto("/petronela");
+    await waitForMixer(page2);
+
+    await expect(page2.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    const micsTab2 = page2.locator(".category-tab.mics");
+    if ((await micsTab2.count()) > 0) await micsTab2.click();
+    await page2.waitForTimeout(500);
+
+    // Solo should still be active after reconnect
+    const soloBtn2 = page2.locator(".solo-btn").first();
+    await expect(soloBtn2).toHaveClass(/on/, { timeout: 5000 });
+
+    // Unsolo to clean up — should restore pre-solo mutes
+    await soloBtn2.click({ force: true });
+    await expect(soloBtn2).toHaveClass(/off/, { timeout: 3000 });
+
+    await ctx2.close();
+  });
+
+  test("unsolo restores original mute states", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto("/");
+    await loginAs(page, "petronela");
+    await page.goto("/petronela");
+    await waitForMixer(page);
+
+    await expect(page.locator(".channel").first()).toBeVisible({ timeout: 15000 });
+
+    const micsTab = page.locator(".category-tab.mics");
+    if ((await micsTab.count()) > 0) await micsTab.click();
+    await page.waitForTimeout(500);
+
+    const channels = page.locator(".channel");
+    const count = await channels.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // Record initial mute states
+    const initialMutes: boolean[] = [];
+    for (let i = 0; i < count; i++) {
+      const cls = (await channels.nth(i).getAttribute("class")) || "";
+      initialMutes.push(cls.includes("muted"));
+    }
+
+    // Solo first channel
+    const soloBtn = page.locator(".solo-btn").first();
+    await soloBtn.click({ force: true });
+    await expect(soloBtn).toHaveClass(/on/, { timeout: 3000 });
+    await page.waitForTimeout(300);
+
+    // Verify non-solo channels are muted
+    for (let i = 1; i < count; i++) {
+      await expect(channels.nth(i)).toHaveClass(/muted/, { timeout: 2000 });
+    }
+
+    // Unsolo
+    await soloBtn.click({ force: true });
+    await expect(soloBtn).toHaveClass(/off/, { timeout: 3000 });
+    await page.waitForTimeout(500);
+
+    // Verify mute states match initial
+    for (let i = 0; i < count; i++) {
+      const cls = (await channels.nth(i).getAttribute("class")) || "";
+      const nowMuted = cls.includes("muted");
+      expect(nowMuted).toBe(initialMutes[i]);
+    }
+
+    await ctx.close();
+  });
 });

--- a/iem-mixer/e2e/tests/live/mixer.spec.ts
+++ b/iem-mixer/e2e/tests/live/mixer.spec.ts
@@ -2166,10 +2166,23 @@ test.describe("Solo sync", () => {
     const soloBtn1 = page1.locator(".solo-btn").first();
     expect(await soloBtn1.count()).toBeGreaterThan(0);
 
-    await soloBtn1.click({ force: true });
-    await page1.waitForTimeout(300);
+    // Ensure REAPER connection is alive (solo requires connected=true)
+    await expect(page1.locator(".connection-status.connected, .mixer-header")).toBeVisible({ timeout: 5000 });
+    await page1.waitForTimeout(1000);
 
-    // Wait for solo to activate on page1 (requires working WS + server)
+    // Click solo — may need retry if connected briefly dropped
+    await soloBtn1.click({ force: true });
+    await page1.waitForTimeout(500);
+
+    // If solo didn't activate (connected was briefly false), retry once
+    const cls1 = (await soloBtn1.getAttribute("class")) || "";
+    if (!cls1.includes("on")) {
+      await page1.waitForTimeout(1000);
+      await soloBtn1.click({ force: true });
+      await page1.waitForTimeout(500);
+    }
+
+    // Wait for solo to activate on page1
     await expect(soloBtn1).toHaveClass(/on/, { timeout: 5000 });
 
     // Verify page2 sees the solo state

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.136.0"
+version = "1.137.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.137.0"
+version = "1.138.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -2398,6 +2398,7 @@ fn ChannelList(
                         let is_currently_soloed = current_soloed.contains(&track_idx);
 
                         if is_currently_soloed {
+                            // UN-SOLO this track
                             let mut new_soloed = current_soloed.clone();
                             new_soloed.remove(&track_idx);
                             if let Some(partner) = partner_idx {
@@ -2405,22 +2406,17 @@ fn ChannelList(
                             }
 
                             if new_soloed.is_empty() {
+                                // Restore pre-solo mutes (optimistic UI)
                                 let saved = pre_solo_mutes.get();
-                                for ch in &all_channels {
-                                    let should_be_muted = saved.get(&ch.track_index).copied().unwrap_or(false);
-                                    let idx = ch.track_index;
-                                    set_channels.update(|chs| {
-                                        if let Some(c) = chs.iter_mut().find(|c| c.track_index == idx) {
-                                            c.muted = should_be_muted;
-                                        }
-                                    });
-                                    ws_send(ws, &iem_core::ClientMsg::SetMute {
-                                        track_index: idx,
-                                        muted: should_be_muted,
-                                    });
-                                }
+                                set_channels.update(|chs| {
+                                    for c in chs.iter_mut() {
+                                        let should_be_muted = saved.get(&c.track_index).copied().unwrap_or(false);
+                                        c.muted = should_be_muted;
+                                    }
+                                });
                                 set_pre_solo_mutes.set(HashMap::new());
                             } else {
+                                // Partial unsolo — mute the desoloed track(s)
                                 set_channels.update(|chs| {
                                     if let Some(ch) = chs.iter_mut().find(|c| c.track_index == track_idx) {
                                         ch.muted = true;
@@ -2431,60 +2427,31 @@ fn ChannelList(
                                         }
                                     }
                                 });
-                                ws_send(ws, &iem_core::ClientMsg::SetMute {
-                                    track_index: track_idx,
-                                    muted: true,
-                                });
-                                if let Some(partner) = partner_idx {
-                                    ws_send(ws, &iem_core::ClientMsg::SetMute {
-                                        track_index: partner,
-                                        muted: true,
-                                    });
-                                }
                             }
+
                             let soloed_vec: Vec<usize> = new_soloed.iter().copied().collect();
                             set_soloed.set(new_soloed);
                             ws_send(ws, &iem_core::ClientMsg::SetSolo { soloed: soloed_vec });
                         } else {
+                            // SOLO this track
                             let was_empty = current_soloed.is_empty();
 
                             if was_empty {
+                                // Save pre-solo mutes for optimistic UI restore
                                 let mut saved_mutes = HashMap::new();
                                 for ch in &all_channels {
                                     saved_mutes.insert(ch.track_index, ch.muted);
                                 }
                                 set_pre_solo_mutes.set(saved_mutes);
-
-                                for ch in &all_channels {
-                                    let should_mute = ch.track_index != track_idx && partner_idx != Some(ch.track_index);
-                                    let idx = ch.track_index;
-                                    set_channels.update(|chs| {
-                                        if let Some(c) = chs.iter_mut().find(|c| c.track_index == idx) {
-                                            c.muted = should_mute;
-                                        }
-                                    });
-                                    ws_send(ws, &iem_core::ClientMsg::SetMute {
-                                        track_index: idx,
-                                        muted: should_mute,
-                                    });
-                                }
-                            } else {
-                                // EXCLUSIVE: mute everything except the new solo target (#131)
-                                for ch in &all_channels {
-                                    let should_mute = ch.track_index != track_idx
-                                        && partner_idx != Some(ch.track_index);
-                                    let idx = ch.track_index;
-                                    set_channels.update(|chs| {
-                                        if let Some(c) = chs.iter_mut().find(|c| c.track_index == idx) {
-                                            c.muted = should_mute;
-                                        }
-                                    });
-                                    ws_send(ws, &iem_core::ClientMsg::SetMute {
-                                        track_index: idx,
-                                        muted: should_mute,
-                                    });
-                                }
                             }
+
+                            // Optimistic UI: mute everything except solo target
+                            set_channels.update(|chs| {
+                                for c in chs.iter_mut() {
+                                    c.muted = c.track_index != track_idx
+                                        && partner_idx != Some(c.track_index);
+                                }
+                            });
 
                             // Build soloed set — exclusive (only new track + partner)
                             let mut new_soloed = std::collections::HashSet::new();

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -1191,10 +1191,40 @@ pub fn MixerPage() -> impl IntoView {
                         Some(c) => c.to_uppercase().chain(chars).collect(),
                     }
                 }}</h1>
-                <div class="header-version">
-                    <span class="header-version-number">{iem_core::version_label()}</span>
-                    <span class="header-version-date">{iem_core::build_datetime()}</span>
-                </div>
+                <Show
+                    when=move || !soloed.get().is_empty()
+                    fallback=|| view! {
+                        <div class="header-version">
+                            <span class="header-version-number">{iem_core::version_label()}</span>
+                            <span class="header-version-date">{iem_core::build_datetime()}</span>
+                        </div>
+                    }
+                >
+                    <button
+                        class="header-solo-btn"
+                        aria-label="Clear solo"
+                        on:click=move |_| {
+                            if !connected.get() {
+                                return;
+                            }
+                            // Optimistic UI: restore pre-solo mutes locally
+                            let saved = pre_solo_mutes.get();
+                            set_channels.update(|chs| {
+                                for c in chs.iter_mut() {
+                                    let should_be_muted = saved.get(&c.track_index).copied().unwrap_or(false);
+                                    c.muted = should_be_muted;
+                                }
+                            });
+                            set_pre_solo_mutes.set(HashMap::new());
+                            set_soloed.set(std::collections::HashSet::new());
+                            // Send empty SetSolo — server restores REAPER mutes and broadcasts
+                            ws_send(ws, &iem_core::ClientMsg::SetSolo { soloed: vec![] });
+                        }
+                    >
+                        "SOLO"
+                        <span class="solo-close">"\u{2715}"</span>
+                    </button>
+                </Show>
                 <button class="settings-btn" on:click=move |_| set_settings_modal_visible.set(true)>
                     "\u{2699}"
                 </button>

--- a/iem-mixer/iem-ui/style.css
+++ b/iem-mixer/iem-ui/style.css
@@ -89,14 +89,15 @@ body {
 }
 
 .mixer-header .back-btn {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border-radius: var(--radius-sm);
   border: none;
   background: transparent;
   color: var(--text-primary);
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   cursor: pointer;
+  padding: 0;
   margin-right: 12px;
 }
 
@@ -1845,13 +1846,17 @@ body {
 
 /* Network mode indicator (LAN/WAN badge in header) */
 .network-indicator {
-  font-size: 0.6em;
+  font-size: 0.5em;
   font-weight: 700;
-  padding: 2px 6px;
+  padding: 2px 3px;
   border-radius: 4px;
-  letter-spacing: 0.05em;
+  letter-spacing: 0;
   flex-shrink: 0;
   margin-right: 4px;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  line-height: 1.1;
+  max-width: 14px;
 }
 
 .network-indicator.local {

--- a/iem-mixer/iem-ui/style.css
+++ b/iem-mixer/iem-ui/style.css
@@ -124,6 +124,55 @@ body {
   white-space: nowrap;
 }
 
+/* Solo active indicator in header (replaces version when solo is active) */
+.header-solo-btn {
+  background: #f59e0b;
+  color: #fff;
+  border: none;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-right: 8px;
+  animation: pulse-solo 1.5s ease-in-out infinite;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.header-solo-btn:hover {
+  background: #d97706;
+}
+
+.header-solo-btn:active {
+  background: #b45309;
+}
+
+.header-solo-btn .solo-close {
+  font-size: 1rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+@keyframes pulse-solo {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(245, 158, 11, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-solo-btn {
+    animation: none;
+  }
+}
+
 /* Connection status dot — dynamic heartbeat when data flows */
 .status-dot {
   width: 10px;

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.137.0"
+version = "1.138.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.136.0"
+version = "1.137.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.137.0",
+  "version": "1.138.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.136.0",
+  "version": "1.137.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",


### PR DESCRIPTION
## Summary

**v1.137.0 — Solo crash recovery:**
- Solo muting moved from UI to server — prevents orphaned mutes on PWA crash
- Pre-solo mute states saved server-side, restored on unsolo
- Solo persists across WebSocket disconnects until explicitly turned off

**v1.138.0 — Solo indicator in header:**
- Yellow "SOLO ✕" button appears in header when solo is active (replaces version display)
- Visible on every category tab — solves visibility problem from v1.137.0 persistence
- One click clears solo from any tab
- Header compacted: smaller back button, vertical LAN/WAN indicator

Fixes #155

## Test plan
- [x] Solo on → unsolo → mute states restored correctly
- [x] Solo on → kill PWA → reopen → solo still active → unsolo → mutes restored
- [x] Solo exclusive mode still works (solo A, then solo B replaces A)
- [x] Multi-tab: solo syncs across tabs
- [x] Header SOLO button clears solo from any tab
- [x] Cross-tab: solo on tab1 → tab2 header shows SOLO button
- [x] Post-deploy E2E: 181/181 tests passing on live iem.lan

🤖 Generated with [Claude Code](https://claude.com/claude-code)