### PR TITLE
fix: review follow-ups for mutation testing gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,7 @@ jobs:
           cargo mutants \
             --in-diff pr.diff \
             --package iem-core \
-            --timeout 120 \
+            --timeout 300 \
             --jobs 4 \
             --no-shuffle
           echo "=== Mutating iem-server (--features audio) ==="
@@ -464,7 +464,7 @@ jobs:
             --in-diff pr.diff \
             --package iem-server \
             --features audio \
-            --timeout 120 \
+            --timeout 300 \
             --jobs 4 \
             --no-shuffle
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.140.0 (2026-04-10)
+
+- **CI**: Mutation testing hardening — raised `cargo-mutants --timeout` from 120s to 300s after observing CPU contention under `--jobs 4` on ubuntu-latest runners. Simplified `iem_core::is_valid_pan` by removing a redundant `is_finite()` check (`Range::contains` already rejects NaN and infinities).
+- **Docs**: Fixed stale comment in `test_reaper_pan_to_ui_nan_maps_to_center` that referenced a removed helper function. Updated the mutation testing spec and marked the plan as superseded by the final implementation.
+
 ### v1.139.0 (2026-04-10)
 
 - **CI**: Added `cargo-mutants` test quality gate. Mutation testing runs on every dev push and PR, mutating only code changed vs `origin/main` (`--in-diff`). Any surviving mutant fails CI. Covers `iem-core` and `iem-server`. Catches weak tests that exercise code without verifying behavior.

--- a/docs/superpowers/plans/2026-04-10-mutation-testing.md
+++ b/docs/superpowers/plans/2026-04-10-mutation-testing.md
@@ -1,5 +1,12 @@
 # Mutation Testing CI Gate — Implementation Plan
 
+> **⚠️ SUPERSEDED:** This plan is a historical record of what was intended at planning time. The code blocks below show the ORIGINAL plan, not the final merged implementation. Several things changed during execution:
+> - `git diff` needs `--relative` to emit workspace-relative paths (without it, cargo-mutants silently matches zero files)
+> - `cargo mutants` must be invoked **twice** (once per package) because `cargo` rejects cross-package feature selection (`--features iem-server/audio`) combined with `--package iem-core`
+> - The `--timeout` value was raised from 120s → 300s after observing CPU contention under `--jobs 4`
+>
+> For the current authoritative description of the gate, see `docs/superpowers/specs/2026-04-10-mutation-testing-design.md` and `.github/workflows/ci.yml`. The commits on PR #159 tell the full iteration story.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add `cargo-mutants` as a hard CI gate so weak tests cannot ship unnoticed. Uses `--in-diff` against `origin/main` so only newly-changed code is gated.

--- a/docs/superpowers/specs/2026-04-10-mutation-testing-design.md
+++ b/docs/superpowers/specs/2026-04-10-mutation-testing-design.md
@@ -38,7 +38,7 @@ cargo test -p iem-core
 cargo test -p iem-server --features audio
 ```
 
-cargo-mutants is invoked once with both packages selected and the `audio` feature enabled, so a single run covers both crates.
+cargo-mutants is invoked **twice**, once per package, because `cargo` rejects cross-package feature selection (`--features iem-server/audio`) when a specific package is selected via `-p`. iem-core runs with default features; iem-server runs with `--features audio`. Each invocation's `--in-diff` sees the same `pr.diff`, and each fails independently if a mutant survives.
 
 ## Trigger
 
@@ -68,14 +68,15 @@ Use `taiki-e/install-action@v2` to install `cargo-mutants` as a prebuilt binary.
 
 ## Diff Computation
 
-For both `dev` push and PR runs, the comparison base is `origin/main`. The job runs:
+For both `dev` push and PR runs, the comparison base is `origin/main`. The job runs from the `iem-mixer/` workspace root:
 
 ```bash
-git fetch origin main --depth=200
-git diff origin/main...HEAD > pr.diff
+git fetch origin main
+git diff --relative origin/main...HEAD \
+  -- 'crates/iem-core/**/*.rs' 'crates/iem-server/**/*.rs' > pr.diff
 ```
 
-The triple-dot (`...`) form gives the diff from the merge base, which is the correct semantic for "what did this branch change relative to main."
+The triple-dot (`...`) form gives the diff from the merge base, which is the correct semantic for "what did this branch change relative to main." The `--relative` flag is load-bearing: it emits pathnames relative to the cwd (the workspace root), matching the workspace-relative paths `cargo mutants --in-diff` expects. Without `--relative`, the diff would contain repo-root-relative paths like `iem-mixer/crates/iem-core/foo.rs` and cargo-mutants would silently match zero files.
 
 If `pr.diff` is empty or contains no Rust changes in the targeted crates, `cargo mutants --in-diff` will exit cleanly with zero mutants generated. The job logs the count explicitly so a green run is auditable.
 
@@ -112,7 +113,7 @@ The job uses the same `~/.cargo` cache pattern as the `test` job (key: `${{ runn
 
 3. **Workspace root vs crate root**: cargo-mutants must run from the workspace root (`iem-mixer/`). Per-crate `--package` flags select what to mutate.
 
-4. **Timeout**: Set `--timeout 120` (per-mutant test timeout, in seconds) so a stuck test doesn't hang the job indefinitely. Default is `auto` (5× baseline), which is usually fine, but explicit is safer for CI.
+4. **Timeout**: Set `--timeout 300` (per-mutant test timeout, in seconds) so a stuck test doesn't hang the job indefinitely. Default is `auto` (5× baseline). 300s gives ~7× headroom over the observed iem-server baseline of 42s, which is necessary because `--jobs 4` causes heavy CPU contention on ubuntu-latest (4-core) runners, tripling both build and test wall times for parallel mutants. The initial value was 120s but that proved fragile — see the v1.139.0 changelog entry and the v1.140.0 follow-up.
 
 5. **Cache invalidation**: When `Cargo.lock` changes, the cache is regenerated. This is acceptable and matches the existing `test` job.
 

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.139.0"
+version = "1.140.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.139.0"
+version = "1.140.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-core/src/types.rs
+++ b/iem-mixer/crates/iem-core/src/types.rs
@@ -129,10 +129,12 @@ pub fn merge_or_replace_channels(
     }
 }
 
-/// Returns true iff `value` is a finite pan value within [-1.0, 1.0].
-/// NaN and infinities return false.
+/// Returns true when `value` is a pan value within [-1.0, 1.0].
+/// NaN and infinities return false: `Range::contains` uses ordered
+/// comparisons, which always return false for NaN, and infinities are
+/// not ≤ 1.0, so the single range check suffices.
 pub fn is_valid_pan(value: f32) -> bool {
-    value.is_finite() && (-1.0..=1.0).contains(&value)
+    (-1.0..=1.0).contains(&value)
 }
 
 /// API error response
@@ -263,8 +265,9 @@ mod tests {
 
     // ================================================================
     // is_valid_pan tests — designed to kill all cargo-mutants mutants:
-    // body replacement (true, false), operator swaps (< vs <=, > vs >=),
-    // && vs ||, and negation removal.
+    // body replacement (true, false), range-endpoint mutations, and
+    // boundary drift. The implementation is a single Range::contains
+    // call, so the mutation surface is small.
     // ================================================================
 
     #[test]
@@ -292,22 +295,13 @@ mod tests {
 
     #[test]
     fn test_is_valid_pan_false_for_non_finite() {
-        // NaN: kills body-replace-with-true and removal of is_finite check.
+        // NaN: Range::contains returns false because NaN comparisons
+        // always return false. Infinities: ±INFINITY is never ≤ 1.0 and
+        // NEG_INFINITY is never ≥ -1.0. So the range check alone
+        // rejects all non-finite inputs without a separate is_finite guard.
         assert!(!is_valid_pan(f32::NAN));
         assert!(!is_valid_pan(f32::INFINITY));
         assert!(!is_valid_pan(f32::NEG_INFINITY));
-    }
-
-    #[test]
-    fn test_is_valid_pan_asymmetric_cases_kill_and_or_swap() {
-        // With && swapped to ||, is_valid_pan(-2.0) becomes
-        // (is_finite=true) || (in -1..=1 = false) = true, which is wrong.
-        // Our assertion above already catches that; this test makes it
-        // explicit for the documentation and for future readers.
-        let outside_below = -2.0_f32;
-        assert!(outside_below.is_finite());
-        assert!(!(-1.0..=1.0).contains(&outside_below));
-        assert!(!is_valid_pan(outside_below));
     }
 
     // ================================================================

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.139.0"
+version = "1.140.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -3378,8 +3378,9 @@ mod tests {
     #[test]
     fn test_reaper_pan_to_ui_nan_maps_to_center() {
         // A malformed REAPER response could yield NaN; we must not leak it
-        // into the UI pan state. clamp_pan maps NaN to 0.0 (REAPER center),
-        // which converts to 0.5 (UI center).
+        // into the UI pan state. The inline NaN guard in reaper_pan_to_ui
+        // returns 0.5 (UI center) directly, avoiding any NaN propagation
+        // into the arithmetic expression below it.
         let ui_pan = reaper_pan_to_ui(f32::NAN);
         assert!(
             (ui_pan - 0.5).abs() < 0.001,

--- a/iem-mixer/e2e/tests/pwa.spec.ts
+++ b/iem-mixer/e2e/tests/pwa.spec.ts
@@ -58,10 +58,38 @@ test.describe("Service Worker — PWA with hashed asset caching", () => {
   test("hashed WASM/JS assets are cached after navigation", async ({
     page,
   }) => {
-    // Navigate to app
+    // Navigate to app — this triggers SW registration
     await page.goto(BASE_URL, { waitUntil: "networkidle" });
 
-    // Reload to ensure SW is active and can intercept fetches
+    // Wait for SW to reach `activated` state BEFORE reloading. Without
+    // this, the reload can race ahead of SW activation on slow runners
+    // and fetches bypass the SW entirely, leaving the cache unpopulated.
+    // Uses the same pattern as the "service worker registers and activates"
+    // test above.
+    const swActivated = await page.evaluate(async () => {
+      if (!("serviceWorker" in navigator)) return "unsupported";
+      const reg = await navigator.serviceWorker.getRegistration();
+      if (!reg) return "not-registered";
+      const sw = reg.active || reg.waiting || reg.installing;
+      if (!sw) return "no-worker";
+      if (sw.state !== "activated") {
+        await new Promise<void>((resolve) => {
+          sw.addEventListener("statechange", () => {
+            if (sw.state === "activated") resolve();
+          });
+          if (sw.state === "activated") resolve();
+        });
+      }
+      return "active";
+    });
+    if (swActivated === "unsupported") {
+      console.log("[SKIP] Service workers not supported in this browser");
+      return;
+    }
+    expect(swActivated).toBe("active");
+
+    // Reload with the SW guaranteed to be active — it will now intercept
+    // fetches for hashed assets and populate the cache.
     await page.reload({ waitUntil: "networkidle" });
 
     // Poll for SW cache to be populated (SW may take several seconds after activation)
@@ -70,7 +98,8 @@ test.describe("Service Worker — PWA with hashed asset caching", () => {
       await page.waitForTimeout(1000);
       cacheInfo = await page.evaluate(async () => {
         const names = await caches.keys();
-        if (!names.includes("iem-assets-v1")) return { exists: false, keys: [] as string[] };
+        if (!names.includes("iem-assets-v1"))
+          return { exists: false, keys: [] as string[] };
         const cache = await caches.open("iem-assets-v1");
         const requests = await cache.keys();
         return {
@@ -83,14 +112,14 @@ test.describe("Service Worker — PWA with hashed asset caching", () => {
 
     expect(cacheInfo.exists).toBe(true);
     // Should have cached at least the WASM and JS loader files
-    const hashedFiles = cacheInfo.keys.filter(
-      (k: string) => /[a-f0-9]{16,}\.(js|wasm)$/.test(k),
+    const hashedFiles = cacheInfo.keys.filter((k: string) =>
+      /[a-f0-9]{16,}\.(js|wasm)$/.test(k),
     );
     expect(hashedFiles.length).toBeGreaterThanOrEqual(1);
 
     // Verify unhashed files are NOT in cache
     const unhashedFiles = cacheInfo.keys.filter(
-      (k: string) => !(/[a-f0-9]{16,}\.(js|wasm)$/.test(k)),
+      (k: string) => !/[a-f0-9]{16,}\.(js|wasm)$/.test(k),
     );
     expect(unhashedFiles).toHaveLength(0);
   });

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.139.0"
+version = "1.140.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.139.0"
+version = "1.140.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.139.0",
+  "version": "1.140.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",


### PR DESCRIPTION
## Summary
Follow-up fixes after PR #159 review. All items from the post-merge code review.

- **Stale comment**: `test_reaper_pan_to_ui_nan_maps_to_center` referenced a removed `clamp_pan` helper. Updated to describe the current inline NaN guard.
- **Timeout hardening**: Raised `cargo-mutants --timeout` from 120s to 300s after observing CPU contention under `--jobs 4` on ubuntu-latest runners (mutant builds take 2-4x baseline; 120s was too tight to cover `cargo test` startup + fast-fail).
- **Simplified `is_valid_pan`**: removed redundant `is_finite()` check. `Range::contains` already rejects NaN (ordered comparisons on NaN always return false) and infinities (not ≤ 1.0).
- **Spec update**: The design spec now describes the two per-package cargo-mutants invocations and the `--relative` flag, matching the final implementation that shipped in v1.139.0.
- **Plan supersession note**: Added a prominent "⚠️ SUPERSEDED" header to the implementation plan, pointing readers to the spec and commit history as the authoritative source.
- **E2E test race fix**: `pwa.spec.ts:58` had a race — it called `page.reload()` without waiting for the service worker to reach `activated`, so on slow runners the SW never intercepted the fetches and the `iem-assets-v1` cache was never populated. Applied the same activation-wait pattern used by the sibling test in the same file. This race was exposed by today's slow runners (11.3s consistent failure vs 2.2s baseline on main) but had been latent since the test was written.
- **Version bump**: 1.139.0 → 1.140.0.

## Test plan
- [x] YAML parses cleanly
- [x] `cargo fmt` clean
- [x] Full dev CI green (10/10 jobs including deploy)
- [x] Mutation Testing job processed 3 real mutants on simplified `is_valid_pan`, 1 caught, 2 unviable, 0 missed, 0 timeouts
- [x] E2E Tests passed (53 tests, including the fixed pwa.spec.ts cache test)
- [x] Production verified on iem.lan after deploy

## References
- Previous PR: #159
- Spec: `docs/superpowers/specs/2026-04-10-mutation-testing-design.md`
- Plan: `docs/superpowers/plans/2026-04-10-mutation-testing.md` (marked superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)