### PR TITLE
fix: SOS alert catch-up for members on WS connect (#150) (v1.141.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.141.0 (2026-04-11)
+
+- **Fix**: SOS alert button now shows the active (red, pulsing) state on the clicking member's own device (#150). On WebSocket connect, the server now catches up a non-engineer member's own active alert state, mirroring the existing engineer catch-up. Previously, reloading the page after triggering SOS left the member's UI stuck in idle while the server still held their alert, and clicking SOS again hit a no-op short-circuit in the CallEngineer handler so the button could never return to active. Restored the `toHaveClass(/active/)` assertion in `alert.spec.ts` as a regression guard.
+
 ### v1.140.0 (2026-04-10)
 
 - **CI**: Mutation testing hardening — raised `cargo-mutants --timeout` from 120s to 300s after observing CPU contention under `--jobs 4` on ubuntu-latest runners. Simplified `iem_core::is_valid_pan` by removing a redundant `is_finite()` check (`Range::contains` already rejects NaN and infinities).

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.140.0"
+version = "1.141.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.140.0"
+version = "1.141.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.140.0"
+version = "1.141.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -951,7 +951,7 @@ pub(crate) fn validate_pan_value(pan: f32) -> Result<(), String> {
 pub(crate) fn build_alert_catchup(
     active_alerts: &std::collections::HashMap<String, (String, String)>,
     member_id: &str,
-) -> Option<ServerMsg> {
+) -> Option<iem_core::ServerMsg> {
     if member_id == "engineer" {
         if active_alerts.is_empty() {
             return None;
@@ -963,9 +963,9 @@ pub(crate) fn build_alert_catchup(
                 from_name: from_name.clone(),
             })
             .collect();
-        Some(ServerMsg::ActiveAlerts { alerts })
+        Some(iem_core::ServerMsg::ActiveAlerts { alerts })
     } else if active_alerts.contains_key(member_id) {
-        Some(ServerMsg::EngineerAlert {
+        Some(iem_core::ServerMsg::EngineerAlert {
             from_member: member_id.to_string(),
             from_name: String::new(),
         })

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -936,6 +936,44 @@ pub(crate) fn validate_pan_value(pan: f32) -> Result<(), String> {
     Ok(())
 }
 
+/// Build the alert catch-up message a WebSocket should send immediately
+/// after connect, or `None` if no catch-up is needed.
+///
+/// - Engineer: receives `ActiveAlerts` listing every active alert across all
+///   members, so the dashboard can restore pending SOS notifications.
+/// - Non-engineer member: receives `EngineerAlert` for their own member_id
+///   if and only if the server still holds an active alert for them. This
+///   is the fix for #150 — without it, reloading the page after triggering
+///   SOS leaves the member's UI idle while the server's `active_alerts`
+///   cache keeps the alert, and the next `CallEngineer` click no-ops in the
+///   `cache.active_alerts.contains_key(...)` short-circuit so the button
+///   can never return to active.
+pub(crate) fn build_alert_catchup(
+    active_alerts: &std::collections::HashMap<String, (String, String)>,
+    member_id: &str,
+) -> Option<ServerMsg> {
+    if member_id == "engineer" {
+        if active_alerts.is_empty() {
+            return None;
+        }
+        let alerts: Vec<iem_core::AlertInfo> = active_alerts
+            .values()
+            .map(|(from_member, from_name)| iem_core::AlertInfo {
+                from_member: from_member.clone(),
+                from_name: from_name.clone(),
+            })
+            .collect();
+        Some(ServerMsg::ActiveAlerts { alerts })
+    } else if active_alerts.contains_key(member_id) {
+        Some(ServerMsg::EngineerAlert {
+            from_member: member_id.to_string(),
+            from_name: String::new(),
+        })
+    } else {
+        None
+    }
+}
+
 // =============================================================================
 // WebSocket handler
 // =============================================================================
@@ -1058,33 +1096,12 @@ async fn handle_ws(
         }
     }
 
-    // Send active alerts to engineer on connect (catch-up)
-    if member_id == "engineer" {
+    // Send alert catch-up on WS connect. Engineer gets all active alerts,
+    // non-engineer members get only their own (so their UI state survives a
+    // page reload — see #150 for the stuck-idle bug this fixes).
+    {
         let cache = state.mixer_cache.read().await;
-        if !cache.active_alerts.is_empty() {
-            let alerts: Vec<iem_core::AlertInfo> = cache
-                .active_alerts
-                .values()
-                .map(|(from_member, from_name)| iem_core::AlertInfo {
-                    from_member: from_member.clone(),
-                    from_name: from_name.clone(),
-                })
-                .collect();
-            let msg = ServerMsg::ActiveAlerts { alerts };
-            let json = serde_json::to_string(&msg).unwrap_or_default();
-            let _ = socket.send(Message::Text(json.into())).await;
-        }
-    } else {
-        // Send member's own active alert on connect (catch-up after reload) (#150).
-        // Without this the member's UI shows idle after a page reload while the
-        // server still holds their alert, and clicking SOS again no-ops in the
-        // CallEngineer handler so the button can never return to active.
-        let cache = state.mixer_cache.read().await;
-        if cache.active_alerts.contains_key(&member_id) {
-            let msg = ServerMsg::EngineerAlert {
-                from_member: member_id.clone(),
-                from_name: String::new(),
-            };
+        if let Some(msg) = build_alert_catchup(&cache.active_alerts, &member_id) {
             let json = serde_json::to_string(&msg).unwrap_or_default();
             let _ = socket.send(Message::Text(json.into())).await;
         }
@@ -2986,6 +3003,101 @@ async fn handle_talkback_ws(mut socket: axum::extract::ws::WebSocket, state: App
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    // ---- Alert catch-up helper (#150) -----------------------------------
+
+    fn alert_entry(from_member: &str, from_name: &str) -> (String, String) {
+        (from_member.to_string(), from_name.to_string())
+    }
+
+    #[test]
+    fn test_build_alert_catchup_engineer_with_no_alerts_returns_none() {
+        let alerts: HashMap<String, (String, String)> = HashMap::new();
+        assert!(build_alert_catchup(&alerts, "engineer").is_none());
+    }
+
+    #[test]
+    fn test_build_alert_catchup_engineer_with_alerts_returns_active_alerts() {
+        let mut alerts = HashMap::new();
+        alerts.insert(
+            "petronela".to_string(),
+            alert_entry("petronela", "PETRONELA"),
+        );
+        alerts.insert("stevo".to_string(), alert_entry("stevo", "STEVO"));
+
+        let msg = build_alert_catchup(&alerts, "engineer")
+            .expect("engineer with alerts should receive ActiveAlerts");
+        match msg {
+            ServerMsg::ActiveAlerts { alerts: out } => {
+                assert_eq!(out.len(), 2);
+                let mut ids: Vec<String> = out.iter().map(|a| a.from_member.clone()).collect();
+                ids.sort();
+                assert_eq!(ids, vec!["petronela".to_string(), "stevo".to_string()]);
+            }
+            other => panic!("expected ActiveAlerts, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_build_alert_catchup_member_with_own_alert_returns_engineer_alert() {
+        let mut alerts = HashMap::new();
+        alerts.insert(
+            "petronela".to_string(),
+            alert_entry("petronela", "PETRONELA"),
+        );
+
+        let msg = build_alert_catchup(&alerts, "petronela")
+            .expect("member with active alert should receive catch-up");
+        match msg {
+            ServerMsg::EngineerAlert {
+                from_member,
+                from_name,
+            } => {
+                assert_eq!(from_member, "petronela");
+                // from_name is intentionally empty on the member side — the
+                // member doesn't need to render a name for their own button.
+                assert_eq!(from_name, "");
+            }
+            other => panic!("expected EngineerAlert, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_build_alert_catchup_member_with_no_alert_returns_none() {
+        let alerts: HashMap<String, (String, String)> = HashMap::new();
+        assert!(build_alert_catchup(&alerts, "petronela").is_none());
+    }
+
+    #[test]
+    fn test_build_alert_catchup_member_only_sees_own_alert_not_other_members() {
+        // Regression guard: a member must NOT get another member's alert.
+        // If this ever returns Some for a member whose id is not a key, the
+        // member's button would incorrectly flash active when a different
+        // member triggered SOS.
+        let mut alerts = HashMap::new();
+        alerts.insert("stevo".to_string(), alert_entry("stevo", "STEVO"));
+        assert!(build_alert_catchup(&alerts, "petronela").is_none());
+    }
+
+    #[test]
+    fn test_build_alert_catchup_member_echo_is_own_id() {
+        // When a member has an active alert, the EngineerAlert echo must
+        // carry THEIR own id, not some other member's. Kills a mutant that
+        // swaps `member_id` for a literal or for a value from the map.
+        let mut alerts = HashMap::new();
+        alerts.insert("petronela".to_string(), alert_entry("x", "y"));
+        alerts.insert("stevo".to_string(), alert_entry("z", "w"));
+
+        let msg = build_alert_catchup(&alerts, "petronela").unwrap();
+        if let ServerMsg::EngineerAlert { from_member, .. } = msg {
+            assert_eq!(from_member, "petronela");
+        } else {
+            panic!("expected EngineerAlert");
+        }
+    }
+
+    // ---- dB conversion --------------------------------------------------
 
     #[test]
     fn test_db_to_reaper_vol_unity() {

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -3098,6 +3098,34 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_build_alert_catchup_engineer_with_own_alert_goes_through_engineer_branch() {
+        // Edge case: if the engineer somehow ends up in `active_alerts`
+        // (e.g. by triggering SOS from their own mixer page), the helper
+        // must still route through the engineer branch and return
+        // ActiveAlerts including their own entry — never EngineerAlert.
+        // This locks in the "engineer_id-first" branching so a future
+        // refactor can't accidentally send engineers a member-style echo.
+        let mut alerts = HashMap::new();
+        alerts.insert("engineer".to_string(), alert_entry("engineer", "ENGINEER"));
+        alerts.insert(
+            "petronela".to_string(),
+            alert_entry("petronela", "PETRONELA"),
+        );
+
+        let msg = build_alert_catchup(&alerts, "engineer")
+            .expect("engineer with alerts should receive ActiveAlerts");
+        match msg {
+            ServerMsg::ActiveAlerts { alerts: out } => {
+                assert_eq!(out.len(), 2);
+                let mut ids: Vec<String> = out.iter().map(|a| a.from_member.clone()).collect();
+                ids.sort();
+                assert_eq!(ids, vec!["engineer".to_string(), "petronela".to_string()]);
+            }
+            other => panic!("expected ActiveAlerts, got {:?}", other),
+        }
+    }
+
     // ---- dB conversion --------------------------------------------------
 
     #[test]

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1074,6 +1074,20 @@ async fn handle_ws(
             let json = serde_json::to_string(&msg).unwrap_or_default();
             let _ = socket.send(Message::Text(json.into())).await;
         }
+    } else {
+        // Send member's own active alert on connect (catch-up after reload) (#150).
+        // Without this the member's UI shows idle after a page reload while the
+        // server still holds their alert, and clicking SOS again no-ops in the
+        // CallEngineer handler so the button can never return to active.
+        let cache = state.mixer_cache.read().await;
+        if cache.active_alerts.contains_key(&member_id) {
+            let msg = ServerMsg::EngineerAlert {
+                from_member: member_id.clone(),
+                from_name: String::new(),
+            };
+            let json = serde_json::to_string(&msg).unwrap_or_default();
+            let _ = socket.send(Message::Text(json.into())).await;
+        }
     }
 
     // Send network mode (local/remote) — updates on every WS reconnect,

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -3003,6 +3003,7 @@ async fn handle_talkback_ws(mut socket: axum::extract::ws::WebSocket, state: App
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iem_core::ServerMsg;
     use std::collections::HashMap;
 
     // ---- Alert catch-up helper (#150) -----------------------------------

--- a/iem-mixer/e2e/tests/live/alert.spec.ts
+++ b/iem-mixer/e2e/tests/live/alert.spec.ts
@@ -52,10 +52,20 @@ test.describe("Band Member Alert Button (#125)", () => {
     await expect(alertBtn).toHaveCount(0);
   });
 
-  test("alert button is clickable and triggers SOS", async ({ page }) => {
-    // NOTE: Active class assertion removed — see #150.
-    // The SOS mechanism works (engineer receives toast, verified in next test)
-    // but the member's button does not receive the "active" CSS class.
+  test("alert button shows active state after click (#150)", async ({ page }) => {
+    // Capture WebSocket frames in both directions for diagnosis on failure.
+    const wsSent: string[] = [];
+    const wsReceived: string[] = [];
+    page.on("websocket", (ws) => {
+      if (!ws.url().includes("/ws/")) return;
+      ws.on("framesent", (f) => {
+        if (typeof f.payload === "string") wsSent.push(f.payload);
+      });
+      ws.on("framereceived", (f) => {
+        if (typeof f.payload === "string") wsReceived.push(f.payload);
+      });
+    });
+
     await page.goto("/");
     const membersResp = await page.request.get("/api/members");
     const members = await membersResp.json();
@@ -69,11 +79,48 @@ test.describe("Band Member Alert Button (#125)", () => {
     const alertBtn = page.locator(".alert-btn");
     await expect(alertBtn).toBeVisible({ timeout: 5000 });
 
-    // Click SOS — verifies button is interactive
-    await alertBtn.click({ force: true });
+    // Wait for the initial ServerMsg::State to arrive before clicking.
+    // The click handler silently drops if `ws.ready_state() != OPEN`
+    // (alert_button.rs:15). First channel rendering is a reliable proxy
+    // for "WS open AND initial state delivered".
+    await page.waitForFunction(
+      () => document.querySelectorAll(".channel").length > 0,
+      { timeout: 10000 },
+    );
 
-    // Button should still be visible after click (not removed from DOM)
-    await expect(alertBtn).toBeVisible();
+    // If the server holds a stale active alert for this member (prior
+    // failed run), it broadcasts a catch-up EngineerAlert right after
+    // initial State — the WS-connect handler added for #150. Give that
+    // async message a moment to propagate through the Leptos signal,
+    // then clear the alert so the main flow starts idle. Without this,
+    // the next CallEngineer click would hit the "alert already active"
+    // short-circuit in proxy.rs and never reach the member's UI.
+    await page.waitForTimeout(300);
+    const residualClass = (await alertBtn.getAttribute("class")) ?? "";
+    if (residualClass.includes("active")) {
+      await alertBtn.click({ force: true });
+      await expect(alertBtn).not.toHaveClass(/active/, { timeout: 5000 });
+    }
+
+    // Click SOS — send CallEngineer, expect `active` class from server echo.
+    await alertBtn.click({ force: true });
+    try {
+      await expect(alertBtn).toHaveClass(/active/, { timeout: 10000 });
+    } catch (err) {
+      console.log("=== WS frames sent by member ===");
+      for (const p of wsSent) console.log("→", p);
+      console.log("=== WS frames received by member ===");
+      for (const p of wsReceived) console.log("←", p);
+      console.log(
+        "=== alert-btn class at failure ===",
+        await alertBtn.getAttribute("class"),
+      );
+      throw err;
+    }
+
+    // Clear the alert so we leave the server in a clean state.
+    await alertBtn.click({ force: true });
+    await expect(alertBtn).not.toHaveClass(/active/, { timeout: 5000 });
   });
 
   test("alert persists until engineer dismisses", async ({ browser }) => {

--- a/iem-mixer/e2e/tests/live/alert.spec.ts
+++ b/iem-mixer/e2e/tests/live/alert.spec.ts
@@ -53,16 +53,26 @@ test.describe("Band Member Alert Button (#125)", () => {
   });
 
   test("alert button shows active state after click (#150)", async ({ page }) => {
-    // Capture WebSocket frames in both directions for diagnosis on failure.
+    // Capture only signal-bearing WebSocket frames for diagnosis on failure.
+    // State and Meters frames carry full mix data (channel names, levels,
+    // per-track meters) which is noise for this test and would also leak
+    // private mixer state into CI logs. Everything we need for diagnosis —
+    // whether CallEngineer went out, whether EngineerAlert came back,
+    // whether AlertCleared was seen — is in the short signal frames.
+    const SIGNAL_EVENTS = /"(event|cmd)"\s*:\s*"(CallEngineer|ClearAlert|EngineerAlert|ActiveAlerts|AlertCleared)"/;
     const wsSent: string[] = [];
     const wsReceived: string[] = [];
     page.on("websocket", (ws) => {
       if (!ws.url().includes("/ws/")) return;
       ws.on("framesent", (f) => {
-        if (typeof f.payload === "string") wsSent.push(f.payload);
+        if (typeof f.payload === "string" && SIGNAL_EVENTS.test(f.payload)) {
+          wsSent.push(f.payload);
+        }
       });
       ws.on("framereceived", (f) => {
-        if (typeof f.payload === "string") wsReceived.push(f.payload);
+        if (typeof f.payload === "string" && SIGNAL_EVENTS.test(f.payload)) {
+          wsReceived.push(f.payload);
+        }
       });
     });
 
@@ -90,14 +100,18 @@ test.describe("Band Member Alert Button (#125)", () => {
 
     // If the server holds a stale active alert for this member (prior
     // failed run), it broadcasts a catch-up EngineerAlert right after
-    // initial State — the WS-connect handler added for #150. Give that
-    // async message a moment to propagate through the Leptos signal,
-    // then clear the alert so the main flow starts idle. Without this,
-    // the next CallEngineer click would hit the "alert already active"
-    // short-circuit in proxy.rs and never reach the member's UI.
-    await page.waitForTimeout(300);
-    const residualClass = (await alertBtn.getAttribute("class")) ?? "";
-    if (residualClass.includes("active")) {
+    // initial State — the WS-connect handler added for #150. Poll for up
+    // to 1s; if the button becomes active we clear it so the main flow
+    // starts idle. If the button stays idle there is nothing to clear
+    // and we proceed immediately — no fixed wait.
+    let hadResidualAlert = false;
+    try {
+      await expect(alertBtn).toHaveClass(/active/, { timeout: 1000 });
+      hadResidualAlert = true;
+    } catch {
+      // No residual — fresh state, proceed.
+    }
+    if (hadResidualAlert) {
       await alertBtn.click({ force: true });
       await expect(alertBtn).not.toHaveClass(/active/, { timeout: 5000 });
     }
@@ -107,9 +121,9 @@ test.describe("Band Member Alert Button (#125)", () => {
     try {
       await expect(alertBtn).toHaveClass(/active/, { timeout: 10000 });
     } catch (err) {
-      console.log("=== WS frames sent by member ===");
+      console.log("=== WS signal frames sent by member ===");
       for (const p of wsSent) console.log("→", p);
-      console.log("=== WS frames received by member ===");
+      console.log("=== WS signal frames received by member ===");
       for (const p of wsReceived) console.log("←", p);
       console.log(
         "=== alert-btn class at failure ===",

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.140.0"
+version = "1.141.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.140.0"
+version = "1.141.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.140.0",
+  "version": "1.141.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",


### PR DESCRIPTION
## Summary

- Non-engineer members now receive their own active-alert state on WebSocket connect, mirroring the existing engineer catch-up. Fixes the bug where reloading the page after triggering SOS left the member's UI stuck in idle while the server still held their alert — clicking SOS again hit the "alert already active" short-circuit in the `CallEngineer` handler, and the button could never return to active without the engineer dismissing or the server restarting.
- Restores the `toHaveClass(/active/)` assertion in `alert.spec.ts` (had been stubbed out with a note pointing to #150). The test now also captures WS frames in both directions for diagnosis on failure, and clears any residual alert from a prior run before the main assertion so it is self-healing.
- Version bump 1.140.0 → 1.141.0.

## Test plan

- [x] Reproduced the bug locally against the deployed server (`http://10.77.9.231`) — captured WS trace showed `{"cmd":"CallEngineer"}` going out but no `EngineerAlert` frame coming back when the server held a stale alert in `cache.active_alerts`.
- [x] Restored `alert.spec.ts` assertion + fixed the server.
- [x] CI green on all 10 jobs including Mutation Testing, CI-side E2E, Build Tauri (Windows), and Deploy to iem.lan (which runs the restored `alert.spec.ts` post-deploy against the freshly-deployed server).
- [x] Post-deploy verification: ran the `#150` test 3x against `http://10.77.9.231` — 3/3 passes in 2-5 seconds.
- [x] Production reports `version: 1.141.0-dev`, `git_hash: 33ed633` (matches dev HEAD).