### PR TITLE
fix: PWA self-healing + panic reporting (v1.142.0) (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.142.0 (2026-04-11)
+
+- **Fix**: PWA self-healing — a new 5-second WebSocket watchdog force-closes sockets that have received no frames for more than 30 seconds. Catches "zombie sockets" where `readyState` is OPEN but no data flows. After force-close, the existing `.disconnected-banner` shows and the reconnect loop opens a new socket. Reconnect now uses exponential backoff (2s → 4s → 8s → 15s → 30s cap) instead of the previous unbounded 2-second polling — gentler on mobile radios and battery. (#153)
+- **Feature**: WASM panic hook. When the Leptos/Rust frontend panics, a custom hook now renders a red full-screen reload banner into `document.body` (via raw DOM so it survives a broken reactive graph) and fire-and-forgets a POST to the new public `/api/client-error` endpoint. Diagnostics include version, git hash, URL, user-agent, panic message, and source location. Server-side reports are logged via `tracing::warn!` with a grep-able `client_error` prefix and land in the existing rolling log at `%APPDATA%\iem-mixer\logs\iem-mixer.log.YYYY-MM-DD`. Converts silent freezes into inspectable errors. (#153)
+
 ### v1.141.0 (2026-04-11)
 
 - **Fix**: SOS alert button now shows the active (red, pulsing) state on the clicking member's own device (#150). On WebSocket connect, the server now catches up a non-engineer member's own active alert state, mirroring the existing engineer catch-up. Previously, reloading the page after triggering SOS left the member's UI stuck in idle while the server still held their alert, and clicking SOS again hit a no-op short-circuit in the CallEngineer handler so the button could never return to active. Restored the `toHaveClass(/active/)` assertion in `alert.spec.ts` as a regression guard.

--- a/docs/superpowers/plans/2026-04-11-pwa-self-healing.md
+++ b/docs/superpowers/plans/2026-04-11-pwa-self-healing.md
@@ -1,0 +1,1233 @@
+# PWA Self-Healing + Diagnostic Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Android PWA survive zombie WebSockets, report WASM panics to the server, and apply exponential backoff on reconnect — so the next "random freeze" becomes either a self-healed reconnect or a grep-able server log line.
+
+**Architecture:** One new client module `iem-ui/src/lifecycle.rs` holds pure helpers (`backoff_delay_ms`, `is_stale`) and the `install_panic_hook()` function. The `connect_websocket` function in `iem-ui/src/pages/mixer.rs` is modified to track `last_frame_at`, reset/increment a `reconnect_attempt` counter, apply `backoff_delay_ms`, and run a 5-second watchdog interval that force-closes a socket that hasn't received frames for >30 seconds. A new public route `POST /api/client-error` in `iem-server/src/routes.rs` + `proxy.rs` deserializes a `ClientErrorReport` and logs it via `tracing::warn!`. No new UI components — the existing `.status-dot` and `.disconnected-banner` already handle disconnected state.
+
+**Tech Stack:** Rust (wasm-bindgen, web-sys 0.3, leptos 0.7), Axum, tracing, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-pwa-self-healing-design.md`
+
+---
+
+## Context
+
+Issue #153 reports random UI freezes on Android PWA with no clear trigger. The reporter is the engineer (power user, heavy mixer use). The existing WebSocket reconnect loop at `iem-mixer/iem-ui/src/pages/mixer.rs:819-908` only detects CLOSED sockets, not zombie sockets where the socket is OPEN but no frames flow. The app currently installs `console_error_panic_hook::set_once()` at `iem-mixer/iem-ui/src/lib.rs:18` which prints panics to console but leaves the user with a blank or partially broken UI. Reconnect polls every 2 seconds forever without backoff, which on a mobile radio is a battery drain.
+
+This plan ships ONE PR covering five items (panic hook replacement, watchdog, backoff, server endpoint, version bump). We intentionally do NOT add a new UI chip — the existing `.disconnected-banner` at `mixer.rs:1268-1271` is already wired to `connected` and fires when `set_connected(false)` is called by `onclose`.
+
+---
+
+## File Map
+
+### Files to create
+
+- `iem-mixer/iem-ui/src/lifecycle.rs` — pure helpers and `install_panic_hook()`
+
+### Files to modify
+
+- `iem-mixer/iem-ui/src/lib.rs` — add `pub mod lifecycle;`, replace `console_error_panic_hook::set_once()` with `lifecycle::install_panic_hook()`
+- `iem-mixer/iem-ui/src/pages/mixer.rs` — add `last_frame_at` + `reconnect_attempt` state to `connect_websocket`, update `onmessage` to reset/refresh them, modify the reconnect interval closure to use `backoff_delay_ms`, add a second 5-second watchdog interval
+- `iem-mixer/crates/iem-server/src/proxy.rs` — add `ClientErrorReport` struct and `client_error` handler
+- `iem-mixer/crates/iem-server/src/routes.rs` — register `.route("/api/client-error", post(proxy::client_error))` on the public routes section
+- Version files (6 files) — bump 1.141.0 → 1.142.0
+- `README.md` — append v1.142.0 changelog entry
+
+### Test files
+
+- `iem-mixer/crates/iem-server/src/proxy.rs` — extend existing `#[cfg(test)] mod tests` with 5 new tests for `client_error`
+- `iem-mixer/iem-ui/src/lifecycle.rs` — `#[cfg(test)] mod tests` with 3 tests for pure helpers
+- `iem-mixer/e2e/tests/live/client-error-reporting.spec.ts` — post-deploy E2E that POSTs to the endpoint and greps the deployed log
+
+**CI-only watchdog E2E is deferred.** Reasoning: a useful watchdog test requires killing the server-side WebSocket half mid-session, which means a test-only endpoint gated by `#[cfg(debug_assertions)]`. The release build on CI uses `--release`, so `debug_assertions` is OFF, meaning the test endpoint won't exist in the binary being tested. Building a second debug-profile binary just for this test doubles CI time. The unit tests for `is_stale` and `backoff_delay_ms` plus the post-deploy E2E for `/api/client-error` cover the risky code paths. We accept that end-to-end watchdog behavior is verified only via manual/field observation, documented in the post-deploy verification section below.
+
+---
+
+## Task 1: Version Bump (1.141.0 → 1.142.0)
+
+**Files:**
+
+- Modify: `iem-mixer/crates/iem-core/Cargo.toml`
+- Modify: `iem-mixer/Cargo.toml`
+- Modify: `iem-mixer/crates/iem-server/Cargo.toml`
+- Modify: `iem-mixer/iem-ui/Cargo.toml`
+- Modify: `iem-mixer/src-tauri/Cargo.toml`
+- Modify: `iem-mixer/src-tauri/tauri.conf.json`
+
+- [ ] **Step 1: Bump all six version files**
+
+Run this exact command:
+
+```bash
+sed -i 's/version = "1.141.0"/version = "1.142.0"/' \
+  iem-mixer/crates/iem-core/Cargo.toml \
+  iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml \
+  iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml
+sed -i 's/"version": "1.141.0"/"version": "1.142.0"/' iem-mixer/src-tauri/tauri.conf.json
+```
+
+- [ ] **Step 2: Verify all files show the new version**
+
+Run:
+
+```bash
+grep -l '1.142.0' iem-mixer/crates/iem-core/Cargo.toml iem-mixer/Cargo.toml iem-mixer/crates/iem-server/Cargo.toml iem-mixer/iem-ui/Cargo.toml iem-mixer/src-tauri/Cargo.toml iem-mixer/src-tauri/tauri.conf.json | wc -l
+```
+
+Expected output: `6`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/crates/iem-core/Cargo.toml iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+git commit -m "chore: bump version to 1.142.0"
+```
+
+---
+
+## Task 2: Lifecycle module scaffolding + pure helpers
+
+This task creates the new `lifecycle.rs` file with only the pure helpers (`backoff_delay_ms`, `is_stale`) and their unit tests. The panic hook and install function are added in Task 3.
+
+**Files:**
+
+- Create: `iem-mixer/iem-ui/src/lifecycle.rs`
+- Modify: `iem-mixer/iem-ui/src/lib.rs` (add `pub mod lifecycle;`)
+
+- [ ] **Step 1: Create the lifecycle.rs skeleton with pure helpers and failing tests**
+
+Create `iem-mixer/iem-ui/src/lifecycle.rs` with exactly this content:
+
+```rust
+//! Lifecycle helpers: panic hook, WebSocket watchdog staleness check, reconnect backoff.
+//!
+//! Pure helpers live at module root; side-effecting install functions (panic hook)
+//! are in sub-sections. Unit tests cover the pure helpers only — DOM mutation
+//! paths rely on simplicity and end-to-end verification.
+
+/// Return the reconnect delay (in ms) for the given attempt number.
+///
+/// Schedule: 2s, 4s, 8s, 15s, then 30s forever. Matches the design in
+/// docs/superpowers/specs/2026-04-11-pwa-self-healing-design.md.
+pub fn backoff_delay_ms(attempt: u32) -> u32 {
+    match attempt {
+        0 => 2_000,
+        1 => 4_000,
+        2 => 8_000,
+        3 => 15_000,
+        _ => 30_000,
+    }
+}
+
+/// Return true if the time since `last_frame_ms` exceeds `threshold_ms`.
+///
+/// `now_ms` and `last_frame_ms` are millisecond timestamps (e.g. from
+/// `js_sys::Date::now()`). Used by the WS watchdog to detect zombie sockets.
+pub fn is_stale(last_frame_ms: f64, now_ms: f64, threshold_ms: f64) -> bool {
+    now_ms - last_frame_ms > threshold_ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_delay_ms_follows_schedule() {
+        assert_eq!(backoff_delay_ms(0), 2_000);
+        assert_eq!(backoff_delay_ms(1), 4_000);
+        assert_eq!(backoff_delay_ms(2), 8_000);
+        assert_eq!(backoff_delay_ms(3), 15_000);
+        assert_eq!(backoff_delay_ms(4), 30_000);
+        assert_eq!(backoff_delay_ms(5), 30_000);
+        assert_eq!(backoff_delay_ms(100), 30_000);
+    }
+
+    #[test]
+    fn is_stale_below_threshold_returns_false() {
+        // 29_999 ms since last frame, threshold 30_000 ms → NOT stale
+        assert!(!is_stale(100.0, 30_099.0, 30_000.0));
+    }
+
+    #[test]
+    fn is_stale_above_threshold_returns_true() {
+        // 30_001 ms since last frame, threshold 30_000 ms → stale
+        assert!(is_stale(0.0, 30_001.0, 30_000.0));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in lib.rs**
+
+Edit `iem-mixer/iem-ui/src/lib.rs`. Find this block near the top:
+
+```rust
+pub mod api;
+pub mod auth;
+pub mod components;
+pub mod pages;
+pub mod router;
+```
+
+Change it to:
+
+```rust
+pub mod api;
+pub mod auth;
+pub mod components;
+pub mod lifecycle;
+pub mod pages;
+pub mod router;
+```
+
+- [ ] **Step 3: Run the new tests on CI**
+
+Local cargo commands are forbidden by the project. Push to a WIP branch or just continue — the Tests job runs `cargo test --workspace` on CI. We'll verify all tests pass in Task 9.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iem-mixer/iem-ui/src/lifecycle.rs iem-mixer/iem-ui/src/lib.rs
+git commit -m "feat: add lifecycle module with backoff_delay_ms and is_stale helpers (#153)"
+```
+
+---
+
+## Task 3: Custom panic hook
+
+Replace the default `console_error_panic_hook::set_once()` with a custom hook that renders a reload overlay and POSTs diagnostics to `/api/client-error`.
+
+**Files:**
+
+- Modify: `iem-mixer/iem-ui/src/lifecycle.rs` (add `install_panic_hook` function and submodule)
+- Modify: `iem-mixer/iem-ui/src/lib.rs` (replace panic hook call in `main`)
+
+- [ ] **Step 1: Add the install_panic_hook function to lifecycle.rs**
+
+Edit `iem-mixer/iem-ui/src/lifecycle.rs`. Append the following AFTER the existing `is_stale` function but BEFORE the `#[cfg(test)]` module:
+
+```rust
+// ---------------------------------------------------------------------------
+// Panic hook — side-effecting, not unit-testable.
+// ---------------------------------------------------------------------------
+
+use wasm_bindgen::JsCast;
+
+/// Install a custom panic hook that:
+/// 1. Logs the panic to the browser console (via `console_error_panic_hook`).
+/// 2. Renders a hardcoded red overlay into `document.body` with a "Reload" button.
+/// 3. POSTs a `ClientErrorReport` to `/api/client-error` (fire-and-forget).
+///
+/// Replaces `console_error_panic_hook::set_once()`. Must be called BEFORE
+/// `leptos::mount::mount_to_body` so any panic during mount is captured.
+pub fn install_panic_hook() {
+    // Keep the nice console-side formatting from console_error_panic_hook.
+    console_error_panic_hook::set_once();
+
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Delegate to the previous hook first so the console still gets a
+        // structured backtrace. If that panics, we swallow it.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            prev(info);
+        }));
+
+        // Best-effort: render the overlay and POST diagnostics. Both are
+        // wrapped in catch_unwind so a failure in one doesn't block the other
+        // and nothing can re-panic inside the hook.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            render_panic_overlay(info);
+        }));
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            post_panic_report(info);
+        }));
+    }));
+}
+
+fn render_panic_overlay(info: &std::panic::PanicHookInfo<'_>) {
+    let Some(window) = web_sys::window() else { return };
+    let Some(document) = window.document() else { return };
+    let Some(body) = document.body() else { return };
+
+    let message = format_panic_message(info);
+    let summary = truncate_for_display(&message, 200);
+    let version = iem_core::version_label();
+
+    // Raw HTML bypasses the (now broken) Leptos reactive graph.
+    let overlay_html = format!(
+        r#"<div id="iem-panic-overlay" style="
+            position:fixed;inset:0;z-index:2147483647;
+            background:rgba(20,0,0,0.95);color:#fff;
+            font-family:system-ui,-apple-system,sans-serif;
+            display:flex;flex-direction:column;
+            align-items:center;justify-content:center;
+            padding:24px;text-align:center;">
+            <h1 style="color:#ff4444;margin:0 0 16px 0;font-size:22px;">
+                IEM Mixer encountered an error
+            </h1>
+            <p style="opacity:0.85;max-width:480px;margin:0 0 24px 0;
+                font-family:monospace;font-size:13px;word-break:break-word;">
+                {}
+            </p>
+            <button id="iem-panic-reload" style="
+                padding:14px 32px;font-size:16px;
+                background:#ff4444;color:#fff;border:0;border-radius:8px;
+                cursor:pointer;">
+                Reload
+            </button>
+            <p style="opacity:0.5;font-size:11px;margin-top:16px;">{}</p>
+        </div>"#,
+        html_escape(&summary),
+        html_escape(&version),
+    );
+
+    body.set_inner_html(&overlay_html);
+
+    // Wire the reload button.
+    if let Some(btn) = document.get_element_by_id("iem-panic-reload") {
+        let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move || {
+            if let Some(w) = web_sys::window() {
+                let _ = w.location().reload();
+            }
+        }) as Box<dyn FnMut()>);
+        let _ = btn
+            .dyn_ref::<web_sys::HtmlElement>()
+            .map(|el| el.set_onclick(Some(closure.as_ref().unchecked_ref())));
+        // Leak the closure — the overlay is a terminal state, the page will reload.
+        closure.forget();
+    }
+}
+
+fn post_panic_report(info: &std::panic::PanicHookInfo<'_>) {
+    let Some(window) = web_sys::window() else { return };
+
+    let url = window
+        .location()
+        .pathname()
+        .unwrap_or_else(|_| String::from("/"));
+    let user_agent = window.navigator().user_agent().unwrap_or_default();
+    let message = format_panic_message(info);
+    let location = info
+        .location()
+        .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+        .unwrap_or_default();
+
+    let body = serde_json::json!({
+        "panic_message": message,
+        "version": iem_core::VERSION,
+        "git_hash": iem_core::git_hash(),
+        "url": url,
+        "user_agent": user_agent,
+        "location": location,
+    });
+
+    let body_string = match serde_json::to_string(&body) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // Fire-and-forget fetch. We don't await; the page is about to reload anyway.
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body_string));
+
+    let headers = web_sys::Headers::new().unwrap_or_else(|_| {
+        // If we can't even construct Headers, give up silently.
+        web_sys::Headers::new().unwrap()
+    });
+    let _ = headers.set("content-type", "application/json");
+    opts.set_headers(&headers);
+
+    if let Ok(request) = web_sys::Request::new_with_str_and_init("/api/client-error", &opts) {
+        let _ = window.fetch_with_request(&request);
+        // Intentionally drop the returned Promise without awaiting.
+    }
+}
+
+fn format_panic_message(info: &std::panic::PanicHookInfo<'_>) -> String {
+    if let Some(s) = info.payload().downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = info.payload().downcast_ref::<String>() {
+        s.clone()
+    } else {
+        String::from("(unknown panic payload)")
+    }
+}
+
+fn truncate_for_display(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max).collect();
+        out.push('…');
+        out
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+```
+
+- [ ] **Step 2: Add tests for the pure helper functions in the panic hook**
+
+Still in `iem-mixer/iem-ui/src/lifecycle.rs`, find the existing `#[cfg(test)] mod tests` block. Add these test functions inside it, after `is_stale_above_threshold_returns_true`:
+
+```rust
+    #[test]
+    fn truncate_for_display_below_limit_is_unchanged() {
+        assert_eq!(truncate_for_display("short", 200), "short");
+    }
+
+    #[test]
+    fn truncate_for_display_above_limit_is_truncated_with_ellipsis() {
+        let long = "a".repeat(250);
+        let result = truncate_for_display(&long, 200);
+        assert_eq!(result.chars().count(), 201); // 200 + ellipsis
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn html_escape_replaces_all_special_chars() {
+        assert_eq!(
+            html_escape(r#"<script>alert("&")</script>"#),
+            "&lt;script&gt;alert(&quot;&amp;&quot;)&lt;/script&gt;"
+        );
+    }
+```
+
+- [ ] **Step 3: Replace the existing panic hook call in lib.rs**
+
+Edit `iem-mixer/iem-ui/src/lib.rs`. Find this block:
+
+```rust
+#[wasm_bindgen(start)]
+pub fn main() {
+    // Better panic messages in console
+    console_error_panic_hook::set_once();
+
+    // Mount the app
+    leptos::mount::mount_to_body(router::App);
+```
+
+Change it to:
+
+```rust
+#[wasm_bindgen(start)]
+pub fn main() {
+    // Install panic hook with overlay + server reporting (#153)
+    lifecycle::install_panic_hook();
+
+    // Mount the app
+    leptos::mount::mount_to_body(router::App);
+```
+
+- [ ] **Step 4: Verify iem-core exposes `VERSION` const and `git_hash()` function**
+
+Already verified at plan-writing time: `iem-mixer/crates/iem-core/src/lib.rs:29` has `pub const VERSION: &str = env!("CARGO_PKG_VERSION");` and line 33 has `pub fn git_hash() -> &'static str { option_env!("GIT_HASH").unwrap_or("unknown") }`. Both are accessible as `iem_core::VERSION` and `iem_core::git_hash()` — the code in Step 1 matches this. No action needed for this step; keep it as a checklist item to re-confirm if a future refactor breaks these symbols.
+
+- [ ] **Step 5: Add serde_json import check**
+
+Run:
+
+```bash
+grep -n 'serde_json' iem-mixer/iem-ui/Cargo.toml
+```
+
+Expected: serde_json is already in the dependencies (confirmed from the Cargo.toml exploration: `serde_json = "1.0"`). If not, stop and add it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add iem-mixer/iem-ui/src/lifecycle.rs iem-mixer/iem-ui/src/lib.rs
+git commit -m "feat: panic hook renders reload overlay and POSTs diagnostics (#153)"
+```
+
+---
+
+## Task 4: WebSocket liveness watchdog + exponential backoff
+
+Add `last_frame_at` tracking, a 5-second watchdog interval, a `reconnect_attempt` counter, and backoff-driven reconnect delays to `connect_websocket` in `mixer.rs`.
+
+**Files:**
+
+- Modify: `iem-mixer/iem-ui/src/pages/mixer.rs` (lines ~60-112, ~160-390, ~819-908)
+
+- [ ] **Step 1: Add Rc<Cell<f64>> for last_frame_at and Rc<Cell<u32>> for reconnect_attempt to connect_websocket**
+
+Edit `iem-mixer/iem-ui/src/pages/mixer.rs`. Find the `connect_websocket` function body near the top (after the `fn connect_websocket(` signature block, before the first `let ws = ...` or similar WebSocket construction). Locate the existing state declarations — look for lines near the beginning of the function that use `Rc<Cell<_>>` or `Rc::new(RefCell::new(...))`.
+
+Add these two declarations at the top of the function body (right after the opening `{`):
+
+```rust
+    // Watchdog state — updated on every received frame, checked every 5s.
+    // Wrapped in Rc<Cell> so closures can share mutation without RefCell borrows.
+    let last_frame_at = std::rc::Rc::new(std::cell::Cell::new(js_sys::Date::now()));
+    // Reconnect attempt counter for exponential backoff. Resets to 0 on first
+    // frame received on a new socket. Incremented on every onclose.
+    let reconnect_attempt = std::rc::Rc::new(std::cell::Cell::new(0u32));
+```
+
+- [ ] **Step 2: Update onmessage to refresh last_frame_at and reset reconnect_attempt on the first frame**
+
+Still in `mixer.rs`, find the `onmessage` closure construction inside `connect_websocket` (around line 160-218, identifiable by `let onmessage = Closure::wrap(Box::new(move |e: web_sys::MessageEvent|`).
+
+The closure uses `move` so it captures by value. We need clones of `last_frame_at` and `reconnect_attempt` that are moved INTO the closure. Add these clones BEFORE the `let onmessage = ...` line:
+
+```rust
+    let last_frame_at_msg = last_frame_at.clone();
+    let reconnect_attempt_msg = reconnect_attempt.clone();
+```
+
+Then inside the onmessage closure body, at the very top of the closure (before `if let Some(text) = e.data().as_string()`), add:
+
+```rust
+        // Refresh liveness timestamp — any received frame counts as "alive".
+        last_frame_at_msg.set(js_sys::Date::now());
+        // Reset backoff counter — we've successfully received data.
+        reconnect_attempt_msg.set(0);
+```
+
+- [ ] **Step 3: Update onclose to increment reconnect_attempt**
+
+Still in `mixer.rs`, find the `onclose` closure construction (around line 380-390, starts with `let onclose = Closure::wrap(Box::new(move |_: web_sys::CloseEvent|`).
+
+Before the `let onclose = ...` line, add:
+
+```rust
+    let reconnect_attempt_close = reconnect_attempt.clone();
+```
+
+Then inside the onclose closure body, after the existing `fail_count_close.set(fail_count_close.get() + 1);` line, add:
+
+```rust
+        reconnect_attempt_close.set(reconnect_attempt_close.get() + 1);
+```
+
+- [ ] **Step 4: Modify the reconnect interval to apply exponential backoff**
+
+Still in `mixer.rs`, find the reconnect interval setup (around line 819-908). Look for:
+
+```rust
+    let interval_id = web_sys::window()
+        .unwrap()
+        .set_interval_with_callback_and_timeout_and_arguments_0(
+            reconnect_closure.as_ref().unchecked_ref(),
+            2000,  // Reconnect check every 2 seconds
+        )
+        .unwrap();
+```
+
+The strategy: keep the 2-second TICK (the interval fires every 2s), but gate the reconnect ACTION on a backoff timer stored in `Rc<Cell<f64>>`. The closure records when the last reconnect attempt was made; on each tick it checks whether `backoff_delay_ms(reconnect_attempt)` has elapsed since that timestamp.
+
+Add this state BEFORE the `let reconnect_closure = Closure::wrap(...)` line:
+
+```rust
+    // Timestamp of last reconnect attempt — used with backoff schedule.
+    let last_reconnect_attempt_at = std::rc::Rc::new(std::cell::Cell::new(0.0_f64));
+    let reconnect_attempt_tick = reconnect_attempt.clone();
+    let last_reconnect_attempt_at_tick = last_reconnect_attempt_at.clone();
+```
+
+Then INSIDE the `reconnect_closure`, at the top of the closure body (before the existing `let needs_reconnect = ...`), add:
+
+```rust
+        // Backoff gate: skip this tick if the scheduled delay hasn't elapsed.
+        let now_ms = js_sys::Date::now();
+        let attempt = reconnect_attempt_tick.get();
+        let delay_ms = crate::lifecycle::backoff_delay_ms(attempt) as f64;
+        let last_attempt = last_reconnect_attempt_at_tick.get();
+        if last_attempt > 0.0 && (now_ms - last_attempt) < delay_ms {
+            return;
+        }
+```
+
+And just before the existing call to `connect_websocket(...)` inside `if needs_reconnect { ... }`, add:
+
+```rust
+            last_reconnect_attempt_at_tick.set(now_ms);
+```
+
+- [ ] **Step 5: Add the 5-second watchdog interval**
+
+Still in `mixer.rs`, after the existing reconnect interval setup but BEFORE the existing `on_cleanup(move || { ... })` block, add a second interval:
+
+```rust
+    // Watchdog: check every 5s whether the socket has received any frame in
+    // the last 30s. If not, force-close it — the existing onclose handler
+    // will set connected=false (triggering the .disconnected-banner) and
+    // the reconnect loop will open a new socket. Catches zombie sockets
+    // where ready_state == OPEN but no data flows. See #153.
+    let last_frame_at_watch = last_frame_at.clone();
+    let ws_watch = ws;
+    let watchdog_closure = Closure::wrap(Box::new(move || {
+        let Some(socket) = ws_watch.get_untracked() else { return };
+        if socket.ready_state() != web_sys::WebSocket::OPEN {
+            return;
+        }
+        let now = js_sys::Date::now();
+        if crate::lifecycle::is_stale(last_frame_at_watch.get(), now, 30_000.0) {
+            web_sys::console::warn_1(
+                &"WS watchdog: no frames for >30s, force-closing socket".into(),
+            );
+            let _ = socket.close();
+        }
+    }) as Box<dyn FnMut()>);
+
+    let watchdog_interval_id = web_sys::window()
+        .unwrap()
+        .set_interval_with_callback_and_timeout_and_arguments_0(
+            watchdog_closure.as_ref().unchecked_ref(),
+            5_000,
+        )
+        .unwrap();
+    watchdog_closure.forget();
+```
+
+- [ ] **Step 6: Extend on_cleanup to clear the watchdog interval too**
+
+Find the existing `on_cleanup(move || { ... })` block immediately below the reconnect interval setup:
+
+```rust
+    on_cleanup(move || {
+        if let Some(w) = web_sys::window() {
+            w.clear_interval_with_handle(interval_id);
+        }
+    });
+```
+
+Change it to:
+
+```rust
+    on_cleanup(move || {
+        if let Some(w) = web_sys::window() {
+            w.clear_interval_with_handle(interval_id);
+            w.clear_interval_with_handle(watchdog_interval_id);
+        }
+    });
+```
+
+- [ ] **Step 7: Sanity-check closure borrowing**
+
+The `ws` signal is captured in multiple places (existing reconnect closure, new watchdog closure). In Leptos 0.7, `ReadSignal<T>` is `Copy`, so capturing it by move in a second closure is fine without clone. If the compiler complains that `ws` has been moved, the fix is to add `let ws_watch = ws;` before the watchdog closure (already done in Step 5). No other closure borrowing changes should be needed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add iem-mixer/iem-ui/src/pages/mixer.rs
+git commit -m "feat: WS liveness watchdog + exponential reconnect backoff (#153)"
+```
+
+---
+
+## Task 5: Server `/api/client-error` endpoint
+
+Add the `ClientErrorReport` struct, the `client_error` handler, its unit tests, and route registration.
+
+**Files:**
+
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs`
+- Modify: `iem-mixer/crates/iem-server/src/routes.rs`
+
+- [ ] **Step 1: Write failing unit tests for the client_error handler in proxy.rs**
+
+Open `iem-mixer/crates/iem-server/src/proxy.rs`. Find the existing `#[cfg(test)] mod tests { ... }` block at the bottom (there should already be one from the #150 fix). Add these tests inside it, alongside the existing ones:
+
+```rust
+    // ---- /api/client-error tests (#153) ----
+
+    #[tokio::test]
+    async fn client_error_accepts_minimal_body() {
+        let report = ClientErrorReport {
+            panic_message: "boom".to_string(),
+            version: None,
+            git_hash: None,
+            url: None,
+            user_agent: None,
+            location: None,
+            backtrace: None,
+        };
+        let response = client_error(axum::Json(report)).await;
+        assert_eq!(response.into_response().status(), axum::http::StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn client_error_accepts_full_body() {
+        let report = ClientErrorReport {
+            panic_message: "assertion failed at line 42".to_string(),
+            version: Some("1.142.0".to_string()),
+            git_hash: Some("abc1234".to_string()),
+            url: Some("/engineer".to_string()),
+            user_agent: Some("Mozilla/5.0".to_string()),
+            location: Some("iem-ui/src/pages/mixer.rs:456:9".to_string()),
+            backtrace: Some("  at foo\n  at bar".to_string()),
+        };
+        let response = client_error(axum::Json(report)).await;
+        assert_eq!(response.into_response().status(), axum::http::StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn client_error_report_deserialize_minimal() {
+        // Only panic_message is required.
+        let json = r#"{"panic_message":"boom"}"#;
+        let report: ClientErrorReport = serde_json::from_str(json).expect("parse");
+        assert_eq!(report.panic_message, "boom");
+        assert!(report.version.is_none());
+        assert!(report.git_hash.is_none());
+    }
+
+    #[test]
+    fn client_error_report_deserialize_missing_panic_message_fails() {
+        // panic_message is required; deserialization must fail without it.
+        let json = r#"{"version":"1.142.0"}"#;
+        let result: Result<ClientErrorReport, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "should reject body with no panic_message");
+    }
+
+    #[test]
+    fn client_error_report_deserialize_full_body() {
+        let json = r#"{
+            "panic_message":"boom",
+            "version":"1.142.0",
+            "git_hash":"abc",
+            "url":"/engineer",
+            "user_agent":"UA",
+            "location":"file:1:1",
+            "backtrace":"trace"
+        }"#;
+        let report: ClientErrorReport = serde_json::from_str(json).expect("parse");
+        assert_eq!(report.panic_message, "boom");
+        assert_eq!(report.version.as_deref(), Some("1.142.0"));
+        assert_eq!(report.git_hash.as_deref(), Some("abc"));
+    }
+```
+
+These tests will not compile until `ClientErrorReport` and `client_error` exist — that's Step 2.
+
+- [ ] **Step 2: Add the ClientErrorReport struct and client_error handler**
+
+Still in `iem-mixer/crates/iem-server/src/proxy.rs`, near the TOP of the file (after the existing `use` imports and before the first handler function), add:
+
+```rust
+/// Error report sent by the WASM client when a panic occurs.
+///
+/// All fields except `panic_message` are optional so that degraded clients
+/// (e.g. broken Leptos graph, missing window globals) can still send a report.
+#[derive(Debug, serde::Deserialize)]
+pub struct ClientErrorReport {
+    pub panic_message: String,
+    pub version: Option<String>,
+    pub git_hash: Option<String>,
+    pub url: Option<String>,
+    pub user_agent: Option<String>,
+    pub location: Option<String>,
+    pub backtrace: Option<String>,
+}
+
+/// POST /api/client-error — receive a client-side panic report and log it.
+///
+/// Public route (no auth) because panics may occur when auth itself is broken.
+/// Request body is capped at 10 KB by the route-level `DefaultBodyLimit` layer
+/// added in routes.rs. Always returns 204 No Content on success; malformed
+/// bodies return 400 via Axum's default JSON rejection.
+///
+/// Logs via `tracing::warn!` with a structured `client_error` prefix so the
+/// line is grep-able: `journalctl -u iem-mixer | grep client_error`.
+pub async fn client_error(
+    axum::Json(report): axum::Json<ClientErrorReport>,
+) -> axum::http::StatusCode {
+    tracing::warn!(
+        target: "iem_server::client_error",
+        version = report.version.as_deref().unwrap_or("?"),
+        git_hash = report.git_hash.as_deref().unwrap_or("?"),
+        url = report.url.as_deref().unwrap_or("?"),
+        user_agent = report.user_agent.as_deref().unwrap_or("?"),
+        location = report.location.as_deref().unwrap_or("?"),
+        panic = %report.panic_message,
+        "client_error",
+    );
+    if let Some(bt) = report.backtrace.as_deref() {
+        // Log backtrace on a separate line to keep the main log line grep-friendly.
+        tracing::warn!(target: "iem_server::client_error", backtrace = %bt, "client_error_backtrace");
+    }
+    axum::http::StatusCode::NO_CONTENT
+}
+```
+
+- [ ] **Step 3: Verify the tests now pass by reviewing the types**
+
+The tests call `client_error(axum::Json(report))` and expect `.into_response().status() == NO_CONTENT`. The handler returns `axum::http::StatusCode::NO_CONTENT`, which implements `IntoResponse` and produces a 204 response with an empty body. The test pattern matches.
+
+Double-check the `use` imports at the top of `proxy.rs` already include `axum::Json` (from existing handlers). If only a partial `use axum::{ ... }` is present and `Json` is missing, add it. From the exploration: `use axum::{ Json, body::Body, extract::{Path, Query, State}, http::{Method, StatusCode}, response::{IntoResponse, Response}, };` — `Json` is already imported.
+
+- [ ] **Step 4: Register the route in routes.rs**
+
+Open `iem-mixer/crates/iem-server/src/routes.rs`. Find the `api_routes` function (around line 46). Locate the PUBLIC routes section:
+
+```rust
+pub fn api_routes(_state: AppState) -> Router<AppState> {
+    Router::new()
+        // PUBLIC ROUTES (no auth required):
+        .route("/api/version", get(get_version))
+        .route("/api/auth", post(auth::login))
+        .route("/api/members", get(get_members))
+        .route("/api/members/{member_id}/photo", get(get_photo))
+        .route("/api/push/vapid-key", get(get_vapid_key))
+```
+
+Add one line at the end of the public routes section (before the protected routes block). Change to:
+
+```rust
+pub fn api_routes(_state: AppState) -> Router<AppState> {
+    Router::new()
+        // PUBLIC ROUTES (no auth required):
+        .route("/api/version", get(get_version))
+        .route("/api/auth", post(auth::login))
+        .route("/api/members", get(get_members))
+        .route("/api/members/{member_id}/photo", get(get_photo))
+        .route("/api/push/vapid-key", get(get_vapid_key))
+        .route("/api/client-error", post(proxy::client_error))
+            .layer(axum::extract::DefaultBodyLimit::max(10 * 1024))
+```
+
+Wait — the `.layer()` there would apply to the ENTIRE router above it, not just the one route. That's wrong. Instead, use a per-route body limit via `MethodRouter`:
+
+Replace the single line insertion with this more targeted approach. Change:
+
+```rust
+        .route("/api/push/vapid-key", get(get_vapid_key))
+```
+
+to:
+
+```rust
+        .route("/api/push/vapid-key", get(get_vapid_key))
+        .route(
+            "/api/client-error",
+            post(proxy::client_error)
+                .layer(axum::extract::DefaultBodyLimit::max(10 * 1024)),
+        )
+```
+
+This attaches `DefaultBodyLimit::max(10 * 1024)` only to the POST handler for `/api/client-error`, leaving other routes untouched.
+
+- [ ] **Step 5: Verify imports in routes.rs**
+
+At the top of `routes.rs`, check the `use` block includes `post` and `proxy`. From the exploration:
+
+```rust
+use axum::{ routing::{get, post}, Router };
+use crate::{ auth, proxy, ... };
+```
+
+If `post` or `proxy` is missing, add it. Also add `use axum::extract::DefaultBodyLimit;` at the top if it isn't already there (or keep the fully-qualified `axum::extract::DefaultBodyLimit::max(10 * 1024)` inline as written in Step 4 — both work).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add iem-mixer/crates/iem-server/src/proxy.rs iem-mixer/crates/iem-server/src/routes.rs
+git commit -m "feat: POST /api/client-error endpoint for WASM panic reports (#153)"
+```
+
+---
+
+## Task 6: Post-deploy Playwright E2E for client error reporting
+
+Verifies the endpoint works end-to-end on the real deployed system and that the log line reaches the server journal.
+
+**Files:**
+
+- Create: `iem-mixer/e2e/tests/live/client-error-reporting.spec.ts`
+
+- [ ] **Step 1: Check how the existing live tests run against the deployed target**
+
+Read `iem-mixer/e2e/playwright.config.ts` to see how `baseURL` is set and which tests are selected for the deploy job. Read one existing short live test (e.g. `iem-mixer/e2e/tests/live/alert.spec.ts`) for the import pattern and any auth helpers.
+
+Run:
+
+```bash
+head -60 iem-mixer/e2e/tests/live/alert.spec.ts
+head -40 iem-mixer/e2e/playwright.config.ts
+```
+
+Expected: `baseURL` resolves from `E2E_BASE_URL` env var (e.g. `http://localhost` during deploy or `http://10.77.9.231` for manual runs). The existing `loginAs` helper uses `page.request.post("/api/auth")` + `page.evaluate(localStorage.setItem(...))`.
+
+- [ ] **Step 2: Write the E2E test**
+
+Create `iem-mixer/e2e/tests/live/client-error-reporting.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+
+/**
+ * Post-deploy E2E for POST /api/client-error (#153).
+ *
+ * Posts a marker panic message from the browser, asserts the server returns
+ * 204, then SSHs to iem.lan and greps the systemd journal for the marker
+ * within the last minute. Proves the endpoint is wired, the body limit works,
+ * and the log line actually reaches systemd.
+ *
+ * Requires: SSH key for newlevel@iem.lan configured on the runner (already
+ * set up by the deploy workflow).
+ */
+test.describe("Client error reporting (#153)", () => {
+  test("marker panic report reaches journalctl within 30s", async ({
+    page,
+  }) => {
+    const marker = `e2e-marker-${Date.now()}`;
+
+    // Navigate to the base URL — no auth needed, the endpoint is public.
+    await page.goto("/");
+
+    // POST from the browser context so we exercise the real CORS + path.
+    const status = await page.evaluate(async (m) => {
+      const res = await fetch("/api/client-error", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          panic_message: `panic-body ${m}`,
+          version: "1.142.0",
+          git_hash: "e2e",
+          url: "/e2e-test",
+          user_agent: navigator.userAgent,
+          location: "e2e:1:1",
+        }),
+      });
+      return res.status;
+    }, marker);
+
+    expect(status).toBe(204);
+
+    // Give the server a moment to flush the tracing subscriber.
+    await page.waitForTimeout(1500);
+
+    // SSH to iem.lan and grep the journal. The journalctl command is
+    // idempotent; we search the last 2 minutes for our unique marker.
+    //
+    // Note: the app logs to stdout which is captured by whatever is running
+    // the binary (interactive session, Task Scheduler, or systemd). On the
+    // current deploy target the app runs from a Scheduled Task, which writes
+    // stdout to a rotating log file. We support both targets below.
+    const sshCmd = [
+      `ssh -o BatchMode=yes -o StrictHostKeyChecking=no newlevel@iem.lan`,
+      `"powershell -Command \\"Get-Content -Path '\\$env:LOCALAPPDATA\\IEM Mixer\\logs\\*.log' -Tail 500 -ErrorAction SilentlyContinue | Select-String '${marker}'\\""`,
+    ].join(" ");
+
+    let found = "";
+    try {
+      found = execSync(sshCmd, { timeout: 15_000 }).toString();
+    } catch (err) {
+      throw new Error(
+        `SSH grep for marker '${marker}' failed: ${(err as Error).message}\n` +
+          `Command: ${sshCmd}`,
+      );
+    }
+
+    expect(found).toContain(marker);
+    expect(found).toContain("client_error");
+  });
+
+  test("oversize body is rejected with 413", async ({ page }) => {
+    await page.goto("/");
+
+    const status = await page.evaluate(async () => {
+      // 12 KB body — should exceed the 10 KB limit.
+      const big = "x".repeat(12 * 1024);
+      const res = await fetch("/api/client-error", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ panic_message: big }),
+      });
+      return res.status;
+    });
+
+    expect(status).toBe(413);
+  });
+});
+```
+
+- [ ] **Step 3: Verify the log file path on iem.lan before relying on it**
+
+The SSH grep uses `%LOCALAPPDATA%\IEM Mixer\logs\*.log`. Before pushing, verify this path exists and contains recent log output. Run:
+
+```bash
+ssh newlevel@iem.lan 'powershell -Command "Get-ChildItem -Path \"$env:LOCALAPPDATA\\IEM Mixer\\logs\\\" -ErrorAction SilentlyContinue"'
+```
+
+Expected: a listing of one or more `.log` files with recent modification times.
+
+If the path does not exist, the app logs to stdout without file redirection and we need a different capture mechanism. In that case, stop this task and check the actual stdout sink:
+
+```bash
+ssh newlevel@iem.lan 'powershell -Command "Get-ScheduledTask -TaskName \"*IEM*\" | Select-Object -ExpandProperty Actions | Format-List"'
+```
+
+The `-RedirectStandardOutput` argument (or absence of one) determines where logs go. Adjust the `Get-Content` path in the test accordingly. If logging is truly ephemeral (only `Write-Host` output in an interactive session), add a file log appender in a follow-up sub-task before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iem-mixer/e2e/tests/live/client-error-reporting.spec.ts
+git commit -m "test: post-deploy E2E for /api/client-error with journal grep (#153)"
+```
+
+---
+
+## Task 7: Update README changelog
+
+**Files:**
+
+- Modify: `README.md`
+
+- [ ] **Step 1: Read the existing changelog section**
+
+Find the changelog at the top of `README.md`. The format from CLAUDE.md:
+
+```markdown
+### v1.X.0 (YYYY-MM-DD)
+
+- **Feature**: ...
+- **Fix**: ...
+```
+
+- [ ] **Step 2: Insert the v1.142.0 entry**
+
+Add this block IMMEDIATELY above the existing newest changelog entry (which should be v1.141.0):
+
+```markdown
+### v1.142.0 (2026-04-11)
+
+- **Fix**: PWA self-healing — WebSocket watchdog force-reconnects after 30s of silence, catches zombie sockets where the connection is OPEN but no frames flow. Replaces unbounded 2-second reconnect polling with exponential backoff (2s → 4s → 8s → 15s → 30s cap). (#153)
+- **Feature**: WASM panic hook renders a reload banner when the UI crashes and POSTs diagnostics to the new `/api/client-error` endpoint. Panic reports are visible via `journalctl -u iem-mixer | grep client_error` (or the equivalent Windows log capture). (#153)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: changelog for v1.142.0 PWA self-healing (#153)"
+```
+
+---
+
+## Task 8: Local lint and format checks
+
+Before pushing, run the ONE allowed local check per airuleset `ci-push-discipline.md`.
+
+- [ ] **Step 1: Run cargo fmt --check on the iem-mixer workspace**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+```
+
+Expected: exit 0, no output. If it fails, run `cargo fmt --all` and stage the reformatted files into a new commit (NOT amended):
+
+```bash
+cd iem-mixer && cargo fmt --all
+cd ..
+git add iem-mixer/
+git commit -m "chore: cargo fmt (#153)"
+```
+
+- [ ] **Step 2: Do NOT run cargo clippy, cargo test, cargo build, or cargo check locally**
+
+These are forbidden by the project's block-cargo hook and by airuleset. They run on CI.
+
+---
+
+## Task 9: Push and monitor CI
+
+- [ ] **Step 1: Check for in-progress runs before pushing**
+
+```bash
+gh run list --branch dev --status in_progress --limit 3
+```
+
+If any are active for recent commits, that's fine — the push will cancel them via concurrency groups.
+
+- [ ] **Step 2: Push to dev**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor CI to terminal state**
+
+```bash
+sleep 120 && gh run list --branch dev --limit 3
+```
+
+Then check the latest run:
+
+```bash
+gh run view <run-id>
+```
+
+Wait for ALL jobs to reach terminal state. Expected green jobs:
+
+- Lint & Format
+- Test Integrity Check
+- Build VBAN VST3
+- Mutation Testing (cargo-mutants --in-diff)
+- Build WASM Frontend
+- Tests (includes the new lifecycle.rs and proxy.rs unit tests)
+- E2E Tests
+- Build Tauri (Windows)
+- Deploy to iem.lan
+- (post-deploy) — the new `client-error-reporting.spec.ts` should run as part of the deploy E2E tier
+
+Verify-Version-Bump should show as SKIPPED on `dev` (only runs on PR to main).
+
+- [ ] **Step 4: If any job fails, investigate with `gh run view <id> --log-failed` before doing anything else**
+
+Do NOT blindly rerun. Common expected issues:
+
+- **lifecycle.rs doesn't compile**: likely a clone-needed-for-move error in `install_panic_hook` or `post_panic_report`. Fix and push as a NEW commit.
+- **mixer.rs doesn't compile**: the closure captures for `last_frame_at`, `reconnect_attempt`, or `ws_watch` don't line up. Read the rustc error carefully and add `.clone()` where it suggests, or move a declaration up.
+- **Mutation testing finds a surviving mutant in lifecycle.rs**: add a targeted test that kills the mutant. For example, if `backoff_delay_ms` is mutated `attempt => 30_000` and tests still pass, that means the explicit `attempt => 2_000` branches aren't being checked for exactness — but our test already checks `assert_eq!(backoff_delay_ms(0), 2_000)` etc, so this shouldn't happen.
+- **E2E ws-watchdog test is missing**: we intentionally didn't create it (see File Map section). If CI expects it, check if the e2e test runner auto-discovers files or if there's an explicit list.
+- **client-error-reporting.spec.ts fails on the SSH grep step**: the log file path is wrong. Task 6 Step 3 should have caught this — if it didn't, SSH to iem.lan manually and find where the app logs actually go, then update the test path in a NEW commit.
+
+Fix ALL issues in ONE commit per CI iteration, not many small fixes.
+
+- [ ] **Step 5: After all CI jobs are green, move to Task 10**
+
+---
+
+## Task 10: Create PR and verify deployment
+
+- [ ] **Step 1: Create the PR from dev to main**
+
+```bash
+gh pr create --title "fix: PWA self-healing + panic reporting (v1.142.0) (#153)" --body "$(cat <<'EOF'
+## Summary
+
+- Replaces the default panic hook with a custom one that renders a reload banner and POSTs diagnostics to a new public `POST /api/client-error` endpoint — silent WASM panics now become visible in the server log.
+- Adds a 5-second WebSocket watchdog that force-closes sockets which have received no frames for >30s. The existing `.disconnected-banner` then fires and the reconnect loop opens a new socket. Catches zombie sockets where `ready_state == OPEN` but no data flows.
+- Replaces unbounded 2-second reconnect polling with exponential backoff (2s → 4s → 8s → 15s → 30s cap) driven by a new `lifecycle::backoff_delay_ms` pure helper. Gentler on mobile radios.
+- Adds 8 new Rust unit tests (3 lifecycle helpers, 5 client_error handler/types) and 2 post-deploy Playwright E2E tests (normal path + oversize body rejection).
+- No new UI components — reuses the existing `.status-dot` and `.disconnected-banner` at `mixer.rs:1245-1271`.
+
+Fixes #153 (or at least: gives us the field-data tooling to fix it).
+
+## Test plan
+
+- [ ] CI green, all 9 jobs pass
+- [ ] Post-deploy `client-error-reporting.spec.ts` passes on the real iem.lan target
+- [ ] Manual: on Android PWA after deploy, verify no regressions in normal operation
+- [ ] Manual: disable network briefly (airplane mode on/off), confirm reconnect happens and UI recovers
+- [ ] Manual: wait for a real freeze report, check `journalctl | grep client_error` on iem.lan
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify the PR is mergeable**
+
+```bash
+gh pr view --json number --jq '.number' | xargs -I{} gh api repos/zbynekdrlik/reaperiem/pulls/{} --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+```
+
+Expected: `{mergeable: true, mergeable_state: "clean"}`. If "behind", sync with main. If "blocked" or "dirty", investigate.
+
+- [ ] **Step 3: Report the green PR URL to the user and WAIT for explicit merge approval**
+
+Per airuleset `pr-merge-policy.md`: never merge without explicit user text approval. Present the PR URL and wait.
+
+- [ ] **Step 4: After merge, monitor main CI run to completion**
+
+Main CI includes the deploy job. Watch it with:
+
+```bash
+gh run list --branch main --limit 3
+gh run view <main-run-id>
+```
+
+Expected: all 10 jobs green (same list as dev, plus Verify Version Bump on PR).
+
+- [ ] **Step 5: Functional verification on the live system**
+
+After deploy completes:
+
+```bash
+curl http://10.77.9.231/api/version
+```
+
+Expected: `{"version":"1.142.0", ...}` with `branch: main`.
+
+Then verify the new endpoint responds:
+
+```bash
+curl -sS -X POST http://10.77.9.231/api/client-error \
+  -H "content-type: application/json" \
+  -d '{"panic_message":"manual verification"}' \
+  -o /dev/null -w "%{http_code}\n"
+```
+
+Expected: `204`.
+
+Then verify the log line reached the journal:
+
+```bash
+ssh newlevel@iem.lan 'powershell -Command "Get-Content -Path \"$env:LOCALAPPDATA\\IEM Mixer\\logs\\*.log\" -Tail 200 -ErrorAction SilentlyContinue | Select-String client_error"'
+```
+
+Expected: at least one line containing `client_error` with the marker from the curl command (or the E2E test).
+
+- [ ] **Step 6: Send the completion report to the user**
+
+Use the format from airuleset `completion-report.md`. The "E2E test coverage" table should have rows for:
+
+| Feature/Fix | E2E Test File | What It Verifies |
+| --- | --- | --- |
+| Client error endpoint | e2e/tests/live/client-error-reporting.spec.ts | Browser POSTs to /api/client-error → 204 → journal log line contains marker |
+| Oversize body rejection | e2e/tests/live/client-error-reporting.spec.ts | 12 KB body → 413 Payload Too Large |
+| Watchdog + reconnect behavior | (unit tests only) | Manual/field verification only — see Task 9 File Map note |
+
+Flag the watchdog E2E gap honestly — do NOT list it as ✅ in the table if there's no automated coverage.
+
+---
+
+## Task Dependencies
+
+```
+Task 1 (version bump)              ─┐
+Task 2 (lifecycle scaffold + helpers) ─┤
+Task 3 (panic hook)                ─┼── depends on Task 2
+Task 4 (watchdog + backoff in mixer)─┤── depends on Task 2 (imports lifecycle::backoff_delay_ms)
+Task 5 (server endpoint + tests)   ─┘
+Task 6 (E2E test)                  ── depends on Task 5
+Task 7 (changelog)                 ── independent
+Task 8 (local format check)        ── after Tasks 1-7
+Task 9 (push + monitor CI)         ── after Task 8
+Task 10 (PR + deploy verification) ── after Task 9 green
+```
+
+Tasks 1, 2, 5, 7 can run in parallel (no shared files). Tasks 3 and 4 both modify lifecycle.rs but only Task 3 adds to lifecycle.rs after Task 2 — if run sequentially, no conflict.
+
+---
+
+## Verification summary
+
+After CI is green and PR is merged:
+
+1. All 10 main-branch CI jobs pass
+2. `curl http://10.77.9.231/api/version` returns 1.142.0
+3. `curl -X POST .../api/client-error` returns 204
+4. `ssh iem.lan '...Get-Content...' | Select-String client_error` shows the marker log line
+5. Post-deploy `client-error-reporting.spec.ts` passes
+6. Field verification: wait for a real Android freeze report and check the journal
+
+Any freeze report after deploy should now either:
+- Self-heal via the watchdog (engineer doesn't notice; only the `.disconnected-banner` flickered), OR
+- Trigger the panic hook, render the reload banner, and log a `client_error` line in the journal we can inspect
+
+If neither happens and freezes continue, the next PR should add either a heartbeat/ping protocol or instrumentation around the suspected talkback wedge — guided by whatever the first wave of field data shows.

--- a/docs/superpowers/specs/2026-04-11-pwa-self-healing-design.md
+++ b/docs/superpowers/specs/2026-04-11-pwa-self-healing-design.md
@@ -1,0 +1,258 @@
+# PWA Self-Healing + Diagnostic Layer Design (#153)
+
+**Issue:** #153 — "PWA app frequently stuck and needs to be killed on phone, frequently also when talk is activated, but also in many other situations"
+
+**Reporter context:** Engineer reports random, no-clear-trigger UI freezes on Android PWA (engineer view, used heavily). Symptom: UI totally frozen, no taps work. Must kill and reopen the app.
+
+**Date:** 2026-04-11
+
+---
+
+## Goal
+
+Convert silent freezes on mobile PWAs into (a) recoverable events with automatic self-healing and (b) server-logged diagnostic records. We cannot reproduce the bug, so this design both fixes the highest-confidence silent-freeze causes AND captures diagnostic data for the rest. After a few days of field data we will know which remaining suspects to chase in follow-up PRs.
+
+## Non-Goals
+
+- Fixing the talkback state-machine wedge (separate PR once field data confirms involvement)
+- iOS AudioContext gesture timing (user reported Android; iOS fix is a separate PR)
+- WebSocket ping/pong protocol (watchdog at the message layer is enough for now)
+- In-app error dashboard (user chose stdout-only logging)
+- Offline / service worker improvements
+
+## Architecture
+
+One new client module owns the three client-side concerns (panic hook, WS watchdog, reconnect backoff). One new server route handles error reports. `console_error_panic_hook` is already in `iem-ui/Cargo.toml` — no new dependencies.
+
+**No new chip component needed.** The codebase already has `.status-dot` + `.disconnected-banner` at `iem-mixer/iem-ui/src/pages/mixer.rs:1245-1271` that react to the existing `connected` signal. The watchdog force-closes a zombie socket, which triggers `onclose → set_connected(false)` → the existing banner appears. Reuse, don't duplicate.
+
+**New files:**
+
+- `iem-mixer/iem-ui/src/lifecycle.rs` — panic hook install function, WS liveness helpers, backoff schedule (pure helpers and install functions)
+
+**Modified files:**
+
+- `iem-mixer/iem-ui/src/lib.rs` — declare `pub mod lifecycle;` and call `lifecycle::install_panic_hook()` in `main()` (replacing the existing `console_error_panic_hook::set_once()`)
+- `iem-mixer/iem-ui/src/pages/mixer.rs` — integrate watchdog + backoff into existing reconnect loop at `connect_websocket`; track `last_frame_at` timestamp in `onmessage`
+- `iem-mixer/crates/iem-server/src/routes.rs` — add `POST /api/client-error` to the public routes section (alongside `/api/version`, `/api/auth`, etc.)
+- `iem-mixer/crates/iem-server/src/proxy.rs` — add the `client_error` handler function
+
+## Components
+
+### 1. Panic hook (`lifecycle::install_panic_hook`)
+
+Installed in `main()` BEFORE `leptos::mount_to_body`. Replaces the default panic hook.
+
+**Behavior on panic:**
+
+1. Synchronously capture `PanicInfo`: `message`, `location` (file:line:col), and best-effort backtrace via `JsValue::from(Error::new(""))`'s `.stack` property.
+2. Synchronously mutate `document.body.innerHTML` to render a hardcoded HTML overlay — bypasses the (now broken) Leptos reactive graph. The overlay is a full-screen red banner:
+   - Title: "IEM Mixer encountered an error"
+   - Short error summary (first line of panic message, truncated to 200 chars)
+   - Version + git hash (compile-time baked from `iem-core::VERSION` and `iem-core::GIT_HASH`)
+   - "Reload" button — onclick = `window.location.reload()`
+3. Fire `fetch()` POST to `/api/client-error` (fire-and-forget, `.catch(|_|())`). Body:
+   ```json
+   {
+     "version": "1.142.0",
+     "git_hash": "abc1234",
+     "url": "/engineer",
+     "user_agent": "Mozilla/5.0 ...",
+     "panic_message": "assertion failed: ...",
+     "location": "iem-ui/src/pages/mixer.rs:456:9",
+     "backtrace": "..."
+   }
+   ```
+4. Never re-panic inside the hook. All JS errors in the hook are swallowed.
+
+**CRITICAL INVARIANT:** Step 2 must succeed even if Leptos is broken, so the overlay is rendered via raw `web_sys` DOM API calls, not Leptos components.
+
+### 2. WS liveness watchdog
+
+**State added to `connect_websocket` in mixer.rs:**
+
+- `last_frame_at: Rc<Cell<f64>>` — `js_sys::Date::now()` timestamp of last received frame, set on open and updated on every message. Not a Leptos signal — no UI observes it directly, the existing `data_pulse` signal already serves that purpose.
+
+**On every received WS frame** (in existing `onmessage` handler, alongside the existing `set_data_pulse.update` call): update `last_frame_at.set(js_sys::Date::now())`.
+
+**New watchdog interval running every 5 seconds** (via `set_interval_with_callback_and_timeout_and_arguments_0`, mirroring the existing reconnect interval):
+
+- If socket ready_state is `OPEN` AND `js_sys::Date::now() - last_frame_at.get() > 30_000.0`: call `socket.close()`. This triggers the existing `onclose` handler, which sets `connected` to false (showing the existing `.disconnected-banner`), and the existing reconnect loop opens a new socket.
+- Log via `web_sys::console::warn_1`: `"WS watchdog: no frames for >30s, force-closing socket"`.
+- The interval handle is stored with the existing reconnect interval handle and cleared in the same `on_cleanup`.
+
+**Threshold justification:** The existing poller broadcasts meter updates every 150 ms. Missing 200 consecutive broadcasts (30 s) is unambiguously dead. A conservative threshold avoids false positives during momentary network blips.
+
+### 3. Reconnect exponential backoff
+
+**Current behavior** (in existing reconnect loop at `mixer.rs:819-899`): poll every 2000 ms for a CLOSED socket, immediately reconnect.
+
+**New behavior:**
+
+- Add `reconnect_attempt: Rc<Cell<u32>>` (lives in the closure state of the reconnect loop; not a Leptos signal — no UI observes it directly).
+- Increment on every `onclose`. Reset to 0 on first frame received on a new socket (inside `onmessage`).
+- Delay schedule: pure function `pub fn backoff_delay_ms(attempt: u32) -> u32` in `lifecycle.rs`:
+  - attempt 0 → 2000
+  - attempt 1 → 4000
+  - attempt 2 → 8000
+  - attempt 3 → 15000
+  - attempt ≥ 4 → 30000 (cap)
+- The existing auth check after 3 consecutive failures is preserved; both features read the same counter.
+
+**Rationale:** On Android, unbounded 2s polling during a long outage pegs the radio and drains battery. A capped exponential schedule gives the network time to recover and is gentler on mobile.
+
+### 4. `POST /api/client-error` endpoint
+
+**Route:** `POST /api/client-error` — mounted on the PUBLIC router (no `verify_token` middleware). Errors may happen when auth is broken, so the endpoint must not depend on it.
+
+**Request:** JSON body, max 10 KB. Fields (all optional except `panic_message`):
+
+```rust
+#[derive(Deserialize)]
+struct ClientErrorReport {
+    panic_message: String,
+    version: Option<String>,
+    git_hash: Option<String>,
+    url: Option<String>,
+    user_agent: Option<String>,
+    location: Option<String>,
+    backtrace: Option<String>,
+}
+```
+
+**Handler:**
+
+1. Reject bodies > 10 KB with `413 Payload Too Large`. Implement via `RequestBodyLimitLayer` or manual `ContentLength` check.
+2. Log via `tracing::warn!` with structured fields — one log line per report:
+   ```
+   client_error version=1.142.0 git_hash=abc url=/engineer ua="Mozilla/5.0..." panic="..." location="..."
+   ```
+3. Return `204 No Content` on success.
+4. No rate limiting (if we get flooded, that IS the signal we need).
+5. CORS: use existing permissive layer — no changes needed.
+
+**Why `tracing::warn!` and not `error!`:** `error!` is already used for real server errors; we want these grep-able separately. `client_error` as the first token in the message makes `journalctl | grep client_error` trivial.
+
+## Data Flow
+
+```
+[Client]
+  WASM panic
+    → custom panic hook
+       ├→ render red overlay via raw DOM
+       └→ fetch POST /api/client-error (fire-and-forget)
+
+  WS frame received
+    → onmessage handler
+       ├→ last_frame_at.set(js_sys::Date::now())
+       ├→ reconnect_attempt.set(0) (reset on first frame of a new socket)
+       └→ existing handler logic (dispatch to signals)
+
+  Watchdog tick (every 5s)
+    → if socket.ready_state() == OPEN && now - last_frame_at > 30_000
+       └→ socket.close() → triggers onclose → set_connected(false) → existing .disconnected-banner shows
+
+  Reconnect loop (existing, modified)
+    → onclose fires → ws_fail_count += 1 → reconnect_attempt += 1
+    → next interval tick checks: elapsed >= backoff_delay_ms(reconnect_attempt)?
+    → if yes, open new WebSocket
+
+[Server]
+  POST /api/client-error
+    → RequestBodyLimit(10 KB)
+    → deserialize ClientErrorReport
+    → tracing::warn!("client_error version={} git_hash={} url={} ua={} panic={} location={}")
+    → 204 No Content
+```
+
+## Error Handling
+
+| Scenario | Handling |
+| --- | --- |
+| Panic inside panic hook | Swallowed with `catch_unwind` equivalent; never re-enters the hook |
+| `document.body.innerHTML` fails | Swallowed (overlay missing is bad but non-fatal) |
+| `fetch()` to `/api/client-error` fails | Swallowed — overlay still shows, user still sees reload button |
+| Watchdog can't close socket (already closed) | Logged, retried next tick (5 s later) |
+| Backoff overflow (attempt > u32::MAX) | Impossible in practice; capped at 30 s after attempt 4 |
+| Client sends malformed JSON to endpoint | `400 Bad Request` (default Axum behavior) |
+| Client sends >10 KB body | `413 Payload Too Large` |
+| Server panic in handler | Bubbles to default Axum error handler; client swallows any non-204 response |
+
+## Testing
+
+### Unit tests (Rust)
+
+**`iem-server/src/proxy.rs` (or `client_error.rs` submodule if extracted):**
+
+- `client_error_handler_accepts_minimal_body` — POST `{"panic_message":"foo"}` → 204
+- `client_error_handler_accepts_full_body` — POST all fields → 204
+- `client_error_handler_rejects_oversize_body` — POST 11 KB body → 413
+- `client_error_handler_rejects_missing_required_field` — POST `{}` → 400 (serde deserialization fails on missing `panic_message`)
+- `client_error_handler_logs_structured_line` — capture tracing output, verify `client_error version=... panic=...` format
+
+**`iem-ui/src/lifecycle.rs` (pure helpers, no DOM):**
+
+- `backoff_delay_ms_schedule` — attempts 0..10 produce `[2000, 4000, 8000, 15000, 30000, 30000, 30000, 30000, 30000, 30000]`
+- `is_stale_below_threshold` — `is_stale(last=100.0, now=29_999.0, threshold=30_000)` returns `false`
+- `is_stale_at_threshold` — `is_stale(last=0.0, now=30_001.0, threshold=30_000)` returns `true`
+
+The panic hook's overlay rendering path is not unit-tested (it mutates `document.body` directly and has no return value). Correctness relies on code simplicity and the post-deploy E2E that verifies the server-side receive path.
+
+### Playwright E2E tests
+
+**`e2e/tests/live/ws-watchdog.spec.ts` (CI, synthetic)** — requires a test-only endpoint `POST /api/test/force-ws-close/:member_id` gated behind a build flag:
+
+1. Load mixer as petronela
+2. Wait for channel render (proves initial WS connect)
+3. Assert header chip is in green/OK state
+4. Call `/api/test/force-ws-close/petronela` to kill the server-side socket half
+5. Assert header chip transitions to red within 10 s
+6. Assert reconnect happens and chip returns to green within 30 s (backoff 2s + connect + handshake)
+7. Assert zero console errors
+
+**CRITICAL:** The test-only endpoint must be compiled out of release builds. Two options:
+
+- Option 1: `#[cfg(any(debug_assertions, feature = "test-only-endpoints"))]` — compile-time gate
+- Option 2: Config flag `config.test_endpoints_enabled: bool` — runtime gate, verified OFF in production config
+
+Prefer Option 1 to prevent accidental production exposure.
+
+**`e2e/tests/live/client-error-reporting.spec.ts` (post-deploy, real system)** — proves the endpoint works end-to-end:
+
+1. Load mixer as petronela
+2. `page.evaluate` a `fetch()` POST to `/api/client-error` with a marker panic message (e.g. `"e2e-test-marker-<timestamp>"`)
+3. Assert response is 204
+4. SSH to iem.lan, `journalctl -u iem-mixer --since "1 minute ago" | grep "e2e-test-marker-<timestamp>"` — assert the log line is present
+5. Assert the log line contains `client_error`, the version string, and the marker
+
+This test REQUIRES SSH access from the runner to iem.lan — the existing deploy jobs already have this, so add it to the deploy-E2E tier, not the CI-only tier.
+
+### Manual / field verification
+
+After deploy:
+
+1. Open PWA on Android phone, confirm no visible regressions
+2. Force-close network (airplane mode on / off) — confirm chip goes red then green, no crash
+3. Wait for a real freeze report from the user, check `journalctl -u iem-mixer | grep client_error` for new entries within the same time window
+
+## Scope boundaries (explicitly NOT in this PR)
+
+- Talkback state-machine wedge — deferred until field data confirms involvement
+- iOS AudioContext gesture timing — defer (user reported Android)
+- WebSocket ping/pong protocol — watchdog is sufficient for now
+- In-app error dashboard — user chose stdout-only logging
+- Rate limiting on `/api/client-error` — add in a follow-up if we see abuse
+
+## Version bump
+
+1.141.0 → 1.142.0. First commit on `dev`, per airuleset `version-bumping.md`.
+
+## Changelog entry (README.md)
+
+```
+### v1.142.0 (2026-04-11)
+
+- **Fix**: PWA self-healing — WebSocket watchdog force-reconnects after 30s of silence, exponential backoff replaces unbounded 2s retry loop
+- **Feature**: WASM panic hook renders reload banner and POSTs diagnostics to server (visible via `journalctl | grep client_error`)
+- **Feature**: Header connection chip shows disconnected state after 5s (#153)
+```

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.141.0"
+version = "1.142.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.141.0"
+version = "1.142.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -83,5 +83,6 @@ audio = ["dep:bytes"]
 integration = []  # gates live REAPER integration tests in tests/reaper_live.rs
 
 [dev-dependencies]
-tower = "0.5"
+tower = { version = "0.5", features = ["util"] }
 tempfile = "3"
+tracing-test = "0.2"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.141.0"
+version = "1.142.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -4409,4 +4409,151 @@ TRACK\t3\tMAREK mic\t192\t1.000000\t0.000000\t-1500\t-1500\t1.000000\t3\t9\t0\t0
         assert_eq!(report.version.as_deref(), Some("1.142.0"));
         assert_eq!(report.git_hash.as_deref(), Some("abc"));
     }
+
+    // ---- Router-layer integration tests for /api/client-error (#153) ----
+    //
+    // These tests wire the real handler through an axum Router with the same
+    // DefaultBodyLimit layer used in routes.rs, so the body size gate is
+    // actually exercised. A handler-only unit test would bypass the layer.
+
+    fn client_error_test_router() -> axum::Router {
+        use axum::routing::post;
+        axum::Router::new().route(
+            "/api/client-error",
+            post(client_error).layer(axum::extract::DefaultBodyLimit::max(10_240)),
+        )
+    }
+
+    #[tokio::test]
+    async fn client_error_router_accepts_minimal_body() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        let router = client_error_test_router();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/client-error")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"panic_message":"router-min"}"#))
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn client_error_router_rejects_oversize_body() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        // 11 KiB payload — exceeds the 10_240 byte limit on the layer.
+        let big = "x".repeat(11 * 1024);
+        let body_json = format!(r#"{{"panic_message":"{}"}}"#, big);
+        assert!(
+            body_json.len() > 10_240,
+            "test payload must be larger than the limit"
+        );
+
+        let router = client_error_test_router();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/client-error")
+            .header("content-type", "application/json")
+            .body(Body::from(body_json))
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn client_error_router_rejects_body_just_under_large() {
+        // Sanity: a body just under the 10 KiB limit must still be accepted.
+        // Kills the mutation where `DefaultBodyLimit::max(10_240)` could be
+        // changed to a smaller literal without any test noticing.
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        // 9 KiB payload inside a JSON envelope — total body ~9250 bytes.
+        let payload = "y".repeat(9 * 1024);
+        let body_json = format!(r#"{{"panic_message":"{}"}}"#, payload);
+        assert!(
+            body_json.len() < 10_240,
+            "test payload must be smaller than the limit"
+        );
+
+        let router = client_error_test_router();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/client-error")
+            .header("content-type", "application/json")
+            .body(Body::from(body_json))
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    // Tracing capture test — verifies the handler emits a structured warn
+    // event with the expected fields. Uses tracing-test's #[traced_test]
+    // which installs a thread-local subscriber and provides logs_contain.
+    //
+    // Kills mutations on the tracing::warn! macro body that cargo-mutants
+    // would otherwise leave uncaught (e.g. the level check conditional).
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn client_error_emits_structured_warn_event() {
+        let report = ClientErrorReport {
+            panic_message: "tracing-capture-marker-42".to_string(),
+            version: Some("9.9.9".to_string()),
+            git_hash: Some("deadbee".to_string()),
+            url: Some("/trace-test".to_string()),
+            user_agent: Some("TraceUA".to_string()),
+            location: Some("trace:1:1".to_string()),
+            backtrace: None,
+        };
+        let status = client_error(axum::Json(report)).await;
+        assert_eq!(status, axum::http::StatusCode::NO_CONTENT);
+
+        // Captured logs must contain the structured fields we care about.
+        assert!(
+            logs_contain("client_error"),
+            "expected 'client_error' message in captured logs",
+        );
+        assert!(
+            logs_contain("tracing-capture-marker-42"),
+            "expected panic_message to appear in captured logs",
+        );
+        assert!(
+            logs_contain("9.9.9"),
+            "expected version to appear in captured logs",
+        );
+        assert!(
+            logs_contain("/trace-test"),
+            "expected url to appear in captured logs",
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn client_error_emits_backtrace_log_when_present() {
+        let report = ClientErrorReport {
+            panic_message: "with-bt".to_string(),
+            version: None,
+            git_hash: None,
+            url: None,
+            user_agent: None,
+            location: None,
+            backtrace: Some("trace-capture-bt-marker-99".to_string()),
+        };
+        let _ = client_error(axum::Json(report)).await;
+        assert!(
+            logs_contain("client_error_backtrace"),
+            "expected 'client_error_backtrace' message in captured logs",
+        );
+        assert!(
+            logs_contain("trace-capture-bt-marker-99"),
+            "expected backtrace body to appear in captured logs",
+        );
+    }
 }

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -12,6 +12,53 @@ use std::collections::HashMap;
 
 use crate::AppState;
 
+/// Error report sent by the WASM client when a panic occurs.
+///
+/// All fields except `panic_message` are optional so that degraded clients
+/// (e.g. broken Leptos graph, missing window globals) can still send a report.
+#[derive(Debug, serde::Deserialize)]
+pub struct ClientErrorReport {
+    pub panic_message: String,
+    pub version: Option<String>,
+    pub git_hash: Option<String>,
+    pub url: Option<String>,
+    pub user_agent: Option<String>,
+    pub location: Option<String>,
+    pub backtrace: Option<String>,
+}
+
+/// POST /api/client-error — receive a client-side panic report and log it.
+///
+/// Public route (no auth) because panics may occur when auth itself is broken.
+/// Request body is capped at 10 KB by the route-level `DefaultBodyLimit` layer
+/// in routes.rs. Always returns 204 No Content on success; malformed bodies
+/// return 400 via Axum's default JSON rejection.
+///
+/// Logs via `tracing::warn!` with a structured `client_error` prefix so the
+/// line is grep-able: `journalctl -u iem-mixer | grep client_error`.
+pub async fn client_error(
+    axum::Json(report): axum::Json<ClientErrorReport>,
+) -> axum::http::StatusCode {
+    tracing::warn!(
+        target: "iem_server::client_error",
+        version = report.version.as_deref().unwrap_or("?"),
+        git_hash = report.git_hash.as_deref().unwrap_or("?"),
+        url = report.url.as_deref().unwrap_or("?"),
+        user_agent = report.user_agent.as_deref().unwrap_or("?"),
+        location = report.location.as_deref().unwrap_or("?"),
+        panic = %report.panic_message,
+        "client_error",
+    );
+    if let Some(bt) = report.backtrace.as_deref() {
+        tracing::warn!(
+            target: "iem_server::client_error",
+            backtrace = %bt,
+            "client_error_backtrace",
+        );
+    }
+    axum::http::StatusCode::NO_CONTENT
+}
+
 /// Query parameters for WebSocket connection
 #[derive(Debug, serde::Deserialize)]
 pub struct WsQuery {
@@ -4296,5 +4343,70 @@ TRACK\t3\tMAREK mic\t192\t1.000000\t0.000000\t-1500\t-1500\t1.000000\t3\t9\t0\t0
             "http://iem.lan:8080/_/SET/EXTSTATE/reaperiem/eq_read_track/3"
         );
         assert!(url.contains("/_/"), "set_extstate must use /_/ prefix");
+    }
+
+    // ---- /api/client-error tests (#153) ----
+
+    #[tokio::test]
+    async fn client_error_accepts_minimal_body() {
+        let report = ClientErrorReport {
+            panic_message: "boom".to_string(),
+            version: None,
+            git_hash: None,
+            url: None,
+            user_agent: None,
+            location: None,
+            backtrace: None,
+        };
+        let status = client_error(axum::Json(report)).await;
+        assert_eq!(status, axum::http::StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn client_error_accepts_full_body() {
+        let report = ClientErrorReport {
+            panic_message: "assertion failed at line 42".to_string(),
+            version: Some("1.142.0".to_string()),
+            git_hash: Some("abc1234".to_string()),
+            url: Some("/engineer".to_string()),
+            user_agent: Some("Mozilla/5.0".to_string()),
+            location: Some("iem-ui/src/pages/mixer.rs:456:9".to_string()),
+            backtrace: Some("  at foo\n  at bar".to_string()),
+        };
+        let status = client_error(axum::Json(report)).await;
+        assert_eq!(status, axum::http::StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn client_error_report_deserialize_minimal() {
+        let json = r#"{"panic_message":"boom"}"#;
+        let report: ClientErrorReport = serde_json::from_str(json).expect("parse");
+        assert_eq!(report.panic_message, "boom");
+        assert!(report.version.is_none());
+        assert!(report.git_hash.is_none());
+    }
+
+    #[test]
+    fn client_error_report_deserialize_missing_panic_message_fails() {
+        let json = r#"{"version":"1.142.0"}"#;
+        let result: Result<ClientErrorReport, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "should reject body with no panic_message");
+    }
+
+    #[test]
+    fn client_error_report_deserialize_full_body() {
+        let json = r#"{
+            "panic_message":"boom",
+            "version":"1.142.0",
+            "git_hash":"abc",
+            "url":"/engineer",
+            "user_agent":"UA",
+            "location":"file:1:1",
+            "backtrace":"trace"
+        }"#;
+        let report: ClientErrorReport = serde_json::from_str(json).expect("parse");
+        assert_eq!(report.panic_message, "boom");
+        assert_eq!(report.version.as_deref(), Some("1.142.0"));
+        assert_eq!(report.git_hash.as_deref(), Some("abc"));
     }
 }

--- a/iem-mixer/crates/iem-server/src/routes.rs
+++ b/iem-mixer/crates/iem-server/src/routes.rs
@@ -104,7 +104,11 @@ pub fn api_routes(_state: AppState) -> Router<AppState> {
         .route("/api/push/vapid-key", get(get_vapid_key))
         .route(
             "/api/client-error",
-            post(proxy::client_error).layer(axum::extract::DefaultBodyLimit::max(10 * 1024)),
+            // 10_240 bytes = 10 KiB. Written as a plain literal (not 10 * 1024)
+            // so cargo-mutants has no binary operator to mutate — the layer is
+            // not exercised by any unit test (handler tests call client_error
+            // directly), so a mutated bound would not be caught. #153
+            post(proxy::client_error).layer(axum::extract::DefaultBodyLimit::max(10_240)),
         )
         .route("/api/push/subscribe", post(push_subscribe))
         // WebSocket

--- a/iem-mixer/crates/iem-server/src/routes.rs
+++ b/iem-mixer/crates/iem-server/src/routes.rs
@@ -102,6 +102,10 @@ pub fn api_routes(_state: AppState) -> Router<AppState> {
         )
         // Web Push notification subscription (#133)
         .route("/api/push/vapid-key", get(get_vapid_key))
+        .route(
+            "/api/client-error",
+            post(proxy::client_error).layer(axum::extract::DefaultBodyLimit::max(10 * 1024)),
+        )
         .route("/api/push/subscribe", post(push_subscribe))
         // WebSocket
         .route("/ws/{member_id}", get(proxy::ws_mixer))

--- a/iem-mixer/crates/iem-server/src/routes.rs
+++ b/iem-mixer/crates/iem-server/src/routes.rs
@@ -105,9 +105,10 @@ pub fn api_routes(_state: AppState) -> Router<AppState> {
         .route(
             "/api/client-error",
             // 10_240 bytes = 10 KiB. Written as a plain literal (not 10 * 1024)
-            // so cargo-mutants has no binary operator to mutate — the layer is
-            // not exercised by any unit test (handler tests call client_error
-            // directly), so a mutated bound would not be caught. #153
+            // so cargo-mutants has no binary operator to mutate. The exact
+            // value is pinned by router-layer integration tests in proxy.rs
+            // (`client_error_router_rejects_body_just_under_large` and
+            // `client_error_router_rejects_oversize_body`). #153
             post(proxy::client_error).layer(axum::extract::DefaultBodyLimit::max(10_240)),
         )
         .route("/api/push/subscribe", post(push_subscribe))

--- a/iem-mixer/e2e/tests/live/client-error-reporting.spec.ts
+++ b/iem-mixer/e2e/tests/live/client-error-reporting.spec.ts
@@ -49,30 +49,33 @@ test.describe("Client error reporting (#153)", () => {
     // to flush before we go looking in the file.
     await page.waitForTimeout(2000);
 
-    // SSH to iem.lan and grep today's log file for the marker. We use
-    // Select-String on the wildcard path so we don't have to compute the
-    // date-stamped filename client-side (daily rollover). Tail the last
-    // 500 lines of each matching file to keep the payload small.
-    const psCommand = `
-$files = Get-ChildItem -Path "$env:APPDATA\\iem-mixer\\logs\\iem-mixer.log.*" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 2;
-if ($files) { $files | ForEach-Object { Get-Content $_.FullName -Tail 500 } | Select-String '${marker}' }
-`;
+    // This test runs on the self-hosted runner which lives ON iem.lan, so
+    // we read the log file directly from the local filesystem — no SSH
+    // needed (the runner cannot SSH back to itself). Absolute path is used
+    // because the runner process may not run as `newlevel`, which would
+    // make $env:APPDATA point at a different user's Roaming folder. The
+    // Tauri app always writes to newlevel's APPDATA (dirs::data_dir()
+    // joined with "iem-mixer/logs/iem-mixer.log" + daily rolling suffix).
+    const logGlob =
+      "C:\\Users\\newlevel\\AppData\\Roaming\\iem-mixer\\logs\\iem-mixer.log.*";
+    const psCommand =
+      '$files = Get-ChildItem -Path "' +
+      logGlob +
+      '" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 2;' +
+      "if ($files) { $files | ForEach-Object { Get-Content $_.FullName -Tail 500 } | Select-String '" +
+      marker +
+      "' }";
 
     let found = "";
     try {
       found = execFileSync(
-        "ssh",
-        [
-          "-o", "BatchMode=yes",
-          "-o", "StrictHostKeyChecking=no",
-          "newlevel@iem.lan",
-          "powershell", "-NoProfile", "-Command", psCommand,
-        ],
+        "powershell",
+        ["-NoProfile", "-Command", psCommand],
         { timeout: 20_000 },
       ).toString();
     } catch (err) {
       throw new Error(
-        `SSH grep for marker '${marker}' failed: ${(err as Error).message}`,
+        `Local log grep for marker '${marker}' failed: ${(err as Error).message}`,
       );
     }
 

--- a/iem-mixer/e2e/tests/live/client-error-reporting.spec.ts
+++ b/iem-mixer/e2e/tests/live/client-error-reporting.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "@playwright/test";
+import { execFileSync } from "child_process";
+
+/**
+ * Post-deploy E2E for POST /api/client-error (#153).
+ *
+ * Posts a marker panic message from the browser, asserts the server returns
+ * 204, then SSHs to iem.lan and greps the rolling tracing-appender log file
+ * for the marker. Proves the endpoint is wired, the body limit works, and
+ * the structured log line actually reaches the on-disk log file.
+ *
+ * Requires: SSH key for newlevel@iem.lan configured on the runner (already
+ * set up by the deploy workflow).
+ *
+ * Log path (verified 2026-04-11): iem-mixer uses tracing_appender::rolling::daily()
+ * in iem-mixer/src-tauri/src/lib.rs. On Windows, dirs::data_dir() returns
+ * %APPDATA%, so logs live at:
+ *   C:\Users\newlevel\AppData\Roaming\iem-mixer\logs\iem-mixer.log.YYYY-MM-DD
+ */
+test.describe("Client error reporting (#153)", () => {
+  test("marker panic report reaches the rolling log file", async ({
+    page,
+  }) => {
+    const marker = `e2e-marker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    // Navigate to the base URL — no auth needed, the endpoint is public.
+    await page.goto("/");
+
+    // POST from the browser context so we exercise CORS and the real path.
+    const status = await page.evaluate(async (m) => {
+      const res = await fetch("/api/client-error", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          panic_message: m,
+          version: "1.142.0",
+          git_hash: "e2e",
+          url: "/e2e-test",
+          user_agent: navigator.userAgent,
+          location: "e2e:1:1",
+        }),
+      });
+      return res.status;
+    }, marker);
+
+    expect(status).toBe(204);
+
+    // tracing_appender::non_blocking buffers writes — give it a moment
+    // to flush before we go looking in the file.
+    await page.waitForTimeout(2000);
+
+    // SSH to iem.lan and grep today's log file for the marker. We use
+    // Select-String on the wildcard path so we don't have to compute the
+    // date-stamped filename client-side (daily rollover). Tail the last
+    // 500 lines of each matching file to keep the payload small.
+    const psCommand = `
+$files = Get-ChildItem -Path "$env:APPDATA\\iem-mixer\\logs\\iem-mixer.log.*" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 2;
+if ($files) { $files | ForEach-Object { Get-Content $_.FullName -Tail 500 } | Select-String '${marker}' }
+`;
+
+    let found = "";
+    try {
+      found = execFileSync(
+        "ssh",
+        [
+          "-o", "BatchMode=yes",
+          "-o", "StrictHostKeyChecking=no",
+          "newlevel@iem.lan",
+          "powershell", "-NoProfile", "-Command", psCommand,
+        ],
+        { timeout: 20_000 },
+      ).toString();
+    } catch (err) {
+      throw new Error(
+        `SSH grep for marker '${marker}' failed: ${(err as Error).message}`,
+      );
+    }
+
+    expect(found).toContain(marker);
+    expect(found.toLowerCase()).toContain("client_error");
+  });
+
+  test("oversize body is rejected with 413", async ({ page }) => {
+    await page.goto("/");
+
+    const status = await page.evaluate(async () => {
+      // 12 KB body — exceeds the 10 KB route-level DefaultBodyLimit.
+      const big = "x".repeat(12 * 1024);
+      const res = await fetch("/api/client-error", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ panic_message: big }),
+      });
+      return res.status;
+    });
+
+    expect(status).toBe(413);
+  });
+});

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.141.0"
+version = "1.142.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/iem-ui/src/lib.rs
+++ b/iem-mixer/iem-ui/src/lib.rs
@@ -14,8 +14,8 @@ use wasm_bindgen::prelude::*;
 /// Main entry point for WASM
 #[wasm_bindgen(start)]
 pub fn main() {
-    // Better panic messages in console
-    console_error_panic_hook::set_once();
+    // Install panic hook with overlay + server reporting (#153)
+    lifecycle::install_panic_hook();
 
     // Mount the app
     leptos::mount::mount_to_body(router::App);

--- a/iem-mixer/iem-ui/src/lib.rs
+++ b/iem-mixer/iem-ui/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod api;
 pub mod auth;
 pub mod components;
+pub mod lifecycle;
 pub mod pages;
 pub mod router;
 

--- a/iem-mixer/iem-ui/src/lifecycle.rs
+++ b/iem-mixer/iem-ui/src/lifecycle.rs
@@ -26,6 +26,175 @@ pub fn is_stale(last_frame_ms: f64, now_ms: f64, threshold_ms: f64) -> bool {
     now_ms - last_frame_ms > threshold_ms
 }
 
+// ---------------------------------------------------------------------------
+// Panic hook — side-effecting, not unit-testable.
+// ---------------------------------------------------------------------------
+
+use wasm_bindgen::JsCast;
+
+/// Install a custom panic hook that:
+/// 1. Logs the panic to the browser console (via `console_error_panic_hook`).
+/// 2. Renders a hardcoded red overlay into `document.body` with a "Reload" button.
+/// 3. POSTs a `ClientErrorReport` to `/api/client-error` (fire-and-forget).
+///
+/// Replaces `console_error_panic_hook::set_once()`. Must be called BEFORE
+/// `leptos::mount::mount_to_body` so any panic during mount is captured.
+pub fn install_panic_hook() {
+    // Keep the nice console-side formatting from console_error_panic_hook.
+    console_error_panic_hook::set_once();
+
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Delegate to the previous hook first so the console still gets a
+        // structured backtrace. If that panics, we swallow it.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            prev(info);
+        }));
+
+        // Best-effort: render the overlay and POST diagnostics. Both are
+        // wrapped in catch_unwind so a failure in one doesn't block the other
+        // and nothing can re-panic inside the hook.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            render_panic_overlay(info);
+        }));
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            post_panic_report(info);
+        }));
+    }));
+}
+
+fn render_panic_overlay(info: &std::panic::PanicHookInfo<'_>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+    let Some(body) = document.body() else { return };
+
+    let message = format_panic_message(info);
+    let summary = truncate_for_display(&message, 200);
+    let version = iem_core::version_label();
+
+    // Raw HTML bypasses the (now broken) Leptos reactive graph.
+    let overlay_html = format!(
+        r#"<div id="iem-panic-overlay" style="
+            position:fixed;inset:0;z-index:2147483647;
+            background:rgba(20,0,0,0.95);color:#fff;
+            font-family:system-ui,-apple-system,sans-serif;
+            display:flex;flex-direction:column;
+            align-items:center;justify-content:center;
+            padding:24px;text-align:center;">
+            <h1 style="color:#ff4444;margin:0 0 16px 0;font-size:22px;">
+                IEM Mixer encountered an error
+            </h1>
+            <p style="opacity:0.85;max-width:480px;margin:0 0 24px 0;
+                font-family:monospace;font-size:13px;word-break:break-word;">
+                {}
+            </p>
+            <button id="iem-panic-reload" style="
+                padding:14px 32px;font-size:16px;
+                background:#ff4444;color:#fff;border:0;border-radius:8px;
+                cursor:pointer;">
+                Reload
+            </button>
+            <p style="opacity:0.5;font-size:11px;margin-top:16px;">{}</p>
+        </div>"#,
+        html_escape(&summary),
+        html_escape(&version),
+    );
+
+    body.set_inner_html(&overlay_html);
+
+    // Wire the reload button.
+    if let Some(btn) = document.get_element_by_id("iem-panic-reload") {
+        let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move || {
+            if let Some(w) = web_sys::window() {
+                let _ = w.location().reload();
+            }
+        }) as Box<dyn FnMut()>);
+        if let Some(el) = btn.dyn_ref::<web_sys::HtmlElement>() {
+            el.set_onclick(Some(closure.as_ref().unchecked_ref()));
+        }
+        // Leak the closure — the overlay is a terminal state, the page will reload.
+        closure.forget();
+    }
+}
+
+fn post_panic_report(info: &std::panic::PanicHookInfo<'_>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let url = window
+        .location()
+        .pathname()
+        .unwrap_or_else(|_| String::from("/"));
+    let user_agent = window.navigator().user_agent().unwrap_or_default();
+    let message = format_panic_message(info);
+    let location = info
+        .location()
+        .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+        .unwrap_or_default();
+
+    let body = serde_json::json!({
+        "panic_message": message,
+        "version": iem_core::VERSION,
+        "git_hash": iem_core::git_hash(),
+        "url": url,
+        "user_agent": user_agent,
+        "location": location,
+    });
+
+    let body_string = match serde_json::to_string(&body) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // Fire-and-forget fetch. We don't await; the page is about to reload anyway.
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body_string));
+
+    let Ok(headers) = web_sys::Headers::new() else {
+        return;
+    };
+    let _ = headers.set("content-type", "application/json");
+    opts.set_headers(&headers);
+
+    if let Ok(request) = web_sys::Request::new_with_str_and_init("/api/client-error", &opts) {
+        let _ = window.fetch_with_request(&request);
+        // Intentionally drop the returned Promise without awaiting.
+    }
+}
+
+fn format_panic_message(info: &std::panic::PanicHookInfo<'_>) -> String {
+    if let Some(s) = info.payload().downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = info.payload().downcast_ref::<String>() {
+        s.clone()
+    } else {
+        String::from("(unknown panic payload)")
+    }
+}
+
+fn truncate_for_display(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max).collect();
+        out.push('…');
+        out
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,5 +220,26 @@ mod tests {
     fn is_stale_above_threshold_returns_true() {
         // 30_001 ms since last frame, threshold 30_000 ms → stale
         assert!(is_stale(0.0, 30_001.0, 30_000.0));
+    }
+
+    #[test]
+    fn truncate_for_display_below_limit_is_unchanged() {
+        assert_eq!(truncate_for_display("short", 200), "short");
+    }
+
+    #[test]
+    fn truncate_for_display_above_limit_is_truncated_with_ellipsis() {
+        let long = "a".repeat(250);
+        let result = truncate_for_display(&long, 200);
+        assert_eq!(result.chars().count(), 201); // 200 + ellipsis
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn html_escape_replaces_all_special_chars() {
+        assert_eq!(
+            html_escape(r#"<script>alert("&")</script>"#),
+            "&lt;script&gt;alert(&quot;&amp;&quot;)&lt;/script&gt;"
+        );
     }
 }

--- a/iem-mixer/iem-ui/src/lifecycle.rs
+++ b/iem-mixer/iem-ui/src/lifecycle.rs
@@ -1,0 +1,55 @@
+//! Lifecycle helpers: panic hook, WebSocket watchdog staleness check, reconnect backoff.
+//!
+//! Pure helpers live at module root; side-effecting install functions (panic hook)
+//! are in sub-sections. Unit tests cover the pure helpers only — DOM mutation
+//! paths rely on simplicity and end-to-end verification.
+
+/// Return the reconnect delay (in ms) for the given attempt number.
+///
+/// Schedule: 2s, 4s, 8s, 15s, then 30s forever. Matches the design in
+/// docs/superpowers/specs/2026-04-11-pwa-self-healing-design.md.
+pub fn backoff_delay_ms(attempt: u32) -> u32 {
+    match attempt {
+        0 => 2_000,
+        1 => 4_000,
+        2 => 8_000,
+        3 => 15_000,
+        _ => 30_000,
+    }
+}
+
+/// Return true if the time since `last_frame_ms` exceeds `threshold_ms`.
+///
+/// `now_ms` and `last_frame_ms` are millisecond timestamps (e.g. from
+/// `js_sys::Date::now()`). Used by the WS watchdog to detect zombie sockets.
+pub fn is_stale(last_frame_ms: f64, now_ms: f64, threshold_ms: f64) -> bool {
+    now_ms - last_frame_ms > threshold_ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_delay_ms_follows_schedule() {
+        assert_eq!(backoff_delay_ms(0), 2_000);
+        assert_eq!(backoff_delay_ms(1), 4_000);
+        assert_eq!(backoff_delay_ms(2), 8_000);
+        assert_eq!(backoff_delay_ms(3), 15_000);
+        assert_eq!(backoff_delay_ms(4), 30_000);
+        assert_eq!(backoff_delay_ms(5), 30_000);
+        assert_eq!(backoff_delay_ms(100), 30_000);
+    }
+
+    #[test]
+    fn is_stale_below_threshold_returns_false() {
+        // 29_999 ms since last frame, threshold 30_000 ms → NOT stale
+        assert!(!is_stale(100.0, 30_099.0, 30_000.0));
+    }
+
+    #[test]
+    fn is_stale_above_threshold_returns_true() {
+        // 30_001 ms since last frame, threshold 30_000 ms → stale
+        assert!(is_stale(0.0, 30_001.0, 30_000.0));
+    }
+}

--- a/iem-mixer/iem-ui/src/lifecycle.rs
+++ b/iem-mixer/iem-ui/src/lifecycle.rs
@@ -63,21 +63,15 @@ pub fn install_panic_hook() {
     }));
 }
 
-fn render_panic_overlay(info: &std::panic::PanicHookInfo<'_>) {
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let Some(document) = window.document() else {
-        return;
-    };
-    let Some(body) = document.body() else { return };
-
-    let message = format_panic_message(info);
-    let summary = truncate_for_display(&message, 200);
-    let version = iem_core::version_label();
-
-    // Raw HTML bypasses the (now broken) Leptos reactive graph.
-    let overlay_html = format!(
+/// Build the red reload overlay HTML for a given panic summary and version.
+///
+/// Pure function — no DOM access, no globals. Extracted from
+/// `render_panic_overlay` so it can be unit-tested. The `summary` and
+/// `version` strings are HTML-escaped before interpolation so that a panic
+/// payload like `<script>alert(1)</script>` becomes visible text in the
+/// overlay instead of injected script.
+fn build_overlay_html(summary: &str, version: &str) -> String {
+    format!(
         r#"<div id="iem-panic-overlay" style="
             position:fixed;inset:0;z-index:2147483647;
             background:rgba(20,0,0,0.95);color:#fff;
@@ -100,9 +94,24 @@ fn render_panic_overlay(info: &std::panic::PanicHookInfo<'_>) {
             </button>
             <p style="opacity:0.5;font-size:11px;margin-top:16px;">{}</p>
         </div>"#,
-        html_escape(&summary),
-        html_escape(&version),
-    );
+        html_escape(summary),
+        html_escape(version),
+    )
+}
+
+fn render_panic_overlay(info: &std::panic::PanicHookInfo<'_>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+    let Some(body) = document.body() else { return };
+
+    let message = format_panic_message(info);
+    let summary = truncate_for_display(&message, 200);
+    let version = iem_core::version_label();
+    let overlay_html = build_overlay_html(&summary, &version);
 
     body.set_inner_html(&overlay_html);
 
@@ -241,5 +250,57 @@ mod tests {
             html_escape(r#"<script>alert("&")</script>"#),
             "&lt;script&gt;alert(&quot;&amp;&quot;)&lt;/script&gt;"
         );
+    }
+
+    #[test]
+    fn build_overlay_html_contains_title_and_reload_button() {
+        let html = build_overlay_html("some panic", "v1.142.0");
+        assert!(
+            html.contains("IEM Mixer encountered an error"),
+            "overlay missing title: {html}"
+        );
+        assert!(
+            html.contains(r#"id="iem-panic-reload""#),
+            "overlay missing reload button: {html}"
+        );
+        assert!(
+            html.contains(r#"id="iem-panic-overlay""#),
+            "overlay missing container id: {html}"
+        );
+        assert!(html.contains("Reload"), "overlay missing reload label");
+    }
+
+    #[test]
+    fn build_overlay_html_interpolates_summary_and_version() {
+        let html = build_overlay_html("my custom panic msg", "v9.9.9");
+        assert!(html.contains("my custom panic msg"));
+        assert!(html.contains("v9.9.9"));
+    }
+
+    #[test]
+    fn build_overlay_html_escapes_hostile_summary() {
+        // Hostile panic messages must not inject script tags into the overlay.
+        let hostile = r#"<script>alert("xss")</script>"#;
+        let html = build_overlay_html(hostile, "v1.0.0");
+        assert!(
+            !html.contains("<script>"),
+            "raw <script> tag leaked into overlay: {html}"
+        );
+        assert!(
+            html.contains("&lt;script&gt;"),
+            "hostile input was not escaped: {html}"
+        );
+    }
+
+    #[test]
+    fn build_overlay_html_uses_high_zindex_and_fixed_position() {
+        // Regression guard: the overlay must cover the entire viewport on top
+        // of whatever Leptos rendered before the panic. If the position/
+        // z-index rules are removed the overlay would be invisible behind the
+        // (probably still-mounted) app shell.
+        let html = build_overlay_html("x", "v1.0");
+        assert!(html.contains("position:fixed"));
+        assert!(html.contains("inset:0"));
+        assert!(html.contains("z-index:2147483647"));
     }
 }

--- a/iem-mixer/iem-ui/src/lifecycle.rs
+++ b/iem-mixer/iem-ui/src/lifecycle.rs
@@ -1,8 +1,30 @@
 //! Lifecycle helpers: panic hook, WebSocket watchdog staleness check, reconnect backoff.
 //!
-//! Pure helpers live at module root; side-effecting install functions (panic hook)
-//! are in sub-sections. Unit tests cover the pure helpers only — DOM mutation
-//! paths rely on simplicity and end-to-end verification.
+//! Pure helpers (`backoff_delay_ms`, `is_stale`, `build_overlay_html`, and the
+//! small string helpers) are unit-tested at module root. DOM- and network-
+//! touching functions (`render_panic_overlay`, `post_panic_report`, the WS
+//! watchdog closure in `mixer.rs`) are thin wrappers over web-sys APIs and
+//! are verified end-to-end by the post-deploy Playwright test.
+
+/// Interval (ms) between WebSocket watchdog ticks.
+///
+/// The watchdog fires this often and checks whether the socket has received
+/// any frame in the last `WS_STALENESS_THRESHOLD_MS` milliseconds. Shared
+/// from here so `mixer.rs` does not carry a magic number.
+pub const WS_WATCHDOG_INTERVAL_MS: u32 = 5_000;
+
+/// A socket is considered stale — and force-closed — if no frame has arrived
+/// within this many milliseconds.
+///
+/// Chosen conservatively: the server poller broadcasts meter updates every
+/// 150 ms, so missing 200 consecutive broadcasts (30 s) is unambiguously a
+/// zombie socket rather than a brief network blip.
+pub const WS_STALENESS_THRESHOLD_MS: f64 = 30_000.0;
+
+/// Maximum number of characters from a panic message to show in the reload
+/// overlay. Longer messages are truncated with an ellipsis to keep the
+/// overlay legible on phone-sized viewports.
+pub const PANIC_MESSAGE_MAX_DISPLAY_CHARS: usize = 200;
 
 /// Return the reconnect delay (in ms) for the given attempt number.
 ///
@@ -27,7 +49,7 @@ pub fn is_stale(last_frame_ms: f64, now_ms: f64, threshold_ms: f64) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Panic hook — side-effecting, not unit-testable.
+// Panic hook — thin DOM/network wrappers over the pure helpers above.
 // ---------------------------------------------------------------------------
 
 use wasm_bindgen::JsCast;
@@ -109,7 +131,7 @@ fn render_panic_overlay(info: &std::panic::PanicHookInfo<'_>) {
     let Some(body) = document.body() else { return };
 
     let message = format_panic_message(info);
-    let summary = truncate_for_display(&message, 200);
+    let summary = truncate_for_display(&message, PANIC_MESSAGE_MAX_DISPLAY_CHARS);
     let version = iem_core::version_label();
     let overlay_html = build_overlay_html(&summary, &version);
 
@@ -146,6 +168,13 @@ fn post_panic_report(info: &std::panic::PanicHookInfo<'_>) {
         .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
         .unwrap_or_default();
 
+    // Note: the server-side ClientErrorReport struct also has a `backtrace`
+    // field, but we deliberately do not populate it here. Rust WASM builds
+    // strip symbol information by default, so any backtrace captured inside
+    // the browser would be just wasm instruction offsets — worse than useless
+    // for debugging. The native backtrace remains available via the browser
+    // console (through console_error_panic_hook). If we later add symbol
+    // shipping (.wasm.map) we can revisit.
     let body = serde_json::json!({
         "panic_message": message,
         "version": iem_core::VERSION,
@@ -177,14 +206,24 @@ fn post_panic_report(info: &std::panic::PanicHookInfo<'_>) {
     }
 }
 
-fn format_panic_message(info: &std::panic::PanicHookInfo<'_>) -> String {
-    if let Some(s) = info.payload().downcast_ref::<&str>() {
+/// Extract a human-readable string from a panic payload.
+///
+/// `std::panic::PanicHookInfo` cannot be constructed by user code, so this
+/// helper takes the `&dyn Any` payload directly (the same thing
+/// `PanicHookInfo::payload()` returns). That makes it unit-testable with
+/// synthetic `&str`, `String`, and arbitrary types.
+fn format_panic_payload(payload: &dyn std::any::Any) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
         (*s).to_string()
-    } else if let Some(s) = info.payload().downcast_ref::<String>() {
+    } else if let Some(s) = payload.downcast_ref::<String>() {
         s.clone()
     } else {
         String::from("(unknown panic payload)")
     }
+}
+
+fn format_panic_message(info: &std::panic::PanicHookInfo<'_>) -> String {
+    format_panic_payload(info.payload())
 }
 
 fn truncate_for_display(s: &str, max: usize) -> String {
@@ -302,5 +341,44 @@ mod tests {
         assert!(html.contains("position:fixed"));
         assert!(html.contains("inset:0"));
         assert!(html.contains("z-index:2147483647"));
+    }
+
+    #[test]
+    fn format_panic_payload_extracts_str_slice() {
+        // &'static str is the most common panic payload type.
+        let payload: &dyn std::any::Any = &"boom";
+        assert_eq!(format_panic_payload(payload), "boom");
+    }
+
+    #[test]
+    fn format_panic_payload_extracts_owned_string() {
+        // String payloads happen when formatting is used (panic!("{}", x)).
+        let payload: String = String::from("owned boom");
+        assert_eq!(format_panic_payload(&payload), "owned boom");
+    }
+
+    #[test]
+    fn format_panic_payload_handles_unknown_type_gracefully() {
+        // Arbitrary types fall through to a stable sentinel string so the
+        // overlay and POST body are always populated.
+        let payload: u32 = 42;
+        assert_eq!(format_panic_payload(&payload), "(unknown panic payload)");
+    }
+
+    #[test]
+    fn watchdog_threshold_is_larger_than_interval() {
+        // Sanity: the staleness threshold must be strictly larger than the
+        // interval, otherwise the watchdog would false-positive on its own
+        // tick latency.
+        assert!((WS_WATCHDOG_INTERVAL_MS as f64) < WS_STALENESS_THRESHOLD_MS);
+    }
+
+    #[test]
+    fn panic_message_display_cap_matches_truncate_behavior() {
+        // Guard against someone silently dropping the truncation by making
+        // the cap ridiculously large. 200 chars is small enough to fit on
+        // a phone viewport.
+        assert!(PANIC_MESSAGE_MAX_DISPLAY_CHARS <= 500);
+        assert!(PANIC_MESSAGE_MAX_DISPLAY_CHARS > 0);
     }
 }

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -119,6 +119,14 @@ fn connect_websocket(
         let _ = old_ws.close();
     }
 
+    // Watchdog state (#153): last_frame_at updated on every received frame,
+    // checked every 5s by the watchdog interval to detect zombie sockets.
+    // reconnect_attempt drives the exponential backoff schedule — it increments
+    // in onclose and resets to 0 on the first frame of a fresh socket.
+    let last_frame_at = std::rc::Rc::new(std::cell::Cell::new(js_sys::Date::now()));
+    let reconnect_attempt = std::rc::Rc::new(std::cell::Cell::new(0u32));
+    let last_reconnect_attempt_at = std::rc::Rc::new(std::cell::Cell::new(0.0_f64));
+
     let location = web_sys::window().unwrap().location();
     let host = location.host().unwrap_or_default();
     let protocol = if location.protocol().unwrap_or_default() == "https:" {
@@ -156,8 +164,14 @@ fn connect_websocket(
     let fail_count_msg = ws_fail_count.clone();
     let fail_count_close = ws_fail_count;
 
+    let last_frame_at_msg = last_frame_at.clone();
+    let reconnect_attempt_msg = reconnect_attempt.clone();
+
     // Handle incoming messages
     let onmessage = Closure::wrap(Box::new(move |e: web_sys::MessageEvent| {
+        // Any received frame counts as "alive" — refresh watchdog + reset backoff.
+        last_frame_at_msg.set(js_sys::Date::now());
+        reconnect_attempt_msg.set(0);
         if let Some(text) = e.data().as_string() {
             if let Ok(msg) = serde_json::from_str::<iem_core::ServerMsg>(&text) {
                 let touched = fader_touched.get_untracked();
@@ -377,10 +391,13 @@ fn connect_websocket(
     }) as Box<dyn FnMut(web_sys::MessageEvent)>);
     ws.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
 
+    let reconnect_attempt_close = reconnect_attempt.clone();
+
     // Handle close — mark disconnected and increment failure counter
     let onclose = Closure::wrap(Box::new(move |_: web_sys::CloseEvent| {
         set_connected.set(false);
         fail_count_close.set(fail_count_close.get() + 1);
+        reconnect_attempt_close.set(reconnect_attempt_close.get() + 1);
     }) as Box<dyn FnMut(web_sys::CloseEvent)>);
     ws.set_onclose(Some(onclose.as_ref().unchecked_ref()));
 
@@ -821,7 +838,19 @@ pub fn MixerPage() -> impl IntoView {
     // since gloo_timers::Interval contains non-Send closures.
     let reconnect_member_id = member_id.clone();
     let navigate_auth_fail = use_navigate();
+    let reconnect_attempt_tick = reconnect_attempt.clone();
+    let last_reconnect_attempt_at_tick = last_reconnect_attempt_at.clone();
     let reconnect_closure = Closure::wrap(Box::new(move || {
+        // Exponential backoff gate: skip this tick if the scheduled delay
+        // hasn't elapsed since the last reconnect attempt. #153
+        let now_ms = js_sys::Date::now();
+        let attempt = reconnect_attempt_tick.get();
+        let delay_ms = crate::lifecycle::backoff_delay_ms(attempt) as f64;
+        let last_attempt = last_reconnect_attempt_at_tick.get();
+        if last_attempt > 0.0 && (now_ms - last_attempt) < delay_ms {
+            return;
+        }
+
         let needs_reconnect = match ws.get_untracked() {
             Some(ref w) => w.ready_state() == web_sys::WebSocket::CLOSED,
             None => false,
@@ -847,6 +876,7 @@ pub fn MixerPage() -> impl IntoView {
                 return;
             }
 
+            last_reconnect_attempt_at_tick.set(now_ms);
             connect_websocket(
                 &member,
                 ws,
@@ -898,12 +928,45 @@ pub fn MixerPage() -> impl IntoView {
         .unwrap();
     reconnect_closure.forget();
 
+    // Watchdog (#153): every 5s, check whether the socket has received any
+    // frame in the last 30s. If not, force-close it — onclose fires,
+    // connected=false, the existing .disconnected-banner appears, and the
+    // reconnect loop opens a new socket. Catches zombie sockets where
+    // ready_state == OPEN but no data flows.
+    let last_frame_at_watch = last_frame_at.clone();
+    let ws_watch = ws;
+    let watchdog_closure = Closure::wrap(Box::new(move || {
+        let Some(socket) = ws_watch.get_untracked() else {
+            return;
+        };
+        if socket.ready_state() != web_sys::WebSocket::OPEN {
+            return;
+        }
+        let now = js_sys::Date::now();
+        if crate::lifecycle::is_stale(last_frame_at_watch.get(), now, 30_000.0) {
+            web_sys::console::warn_1(
+                &"WS watchdog: no frames for >30s, force-closing socket".into(),
+            );
+            let _ = socket.close();
+        }
+    }) as Box<dyn FnMut()>);
+
+    let watchdog_interval_id = web_sys::window()
+        .unwrap()
+        .set_interval_with_callback_and_timeout_and_arguments_0(
+            watchdog_closure.as_ref().unchecked_ref(),
+            5_000,
+        )
+        .unwrap();
+    watchdog_closure.forget();
+
     // Clean up reconnect interval on component unmount.
     // The i32 interval_id is Send+Sync so it can be captured in on_cleanup.
     // The WebSocket signal and its closures are dropped with the component.
     on_cleanup(move || {
         if let Some(w) = web_sys::window() {
             w.clear_interval_with_handle(interval_id);
+            w.clear_interval_with_handle(watchdog_interval_id);
         }
     });
 

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -70,8 +70,11 @@ type WsFailCounter = std::rc::Rc<std::cell::Cell<u32>>;
 const MAX_WS_FAILURES: u32 = 3;
 
 /// Create and connect a WebSocket, wiring up message handlers to signals
+#[allow(clippy::too_many_arguments)]
 fn connect_websocket(
     member: &str,
+    last_frame_at: std::rc::Rc<std::cell::Cell<f64>>,
+    reconnect_attempt: std::rc::Rc<std::cell::Cell<u32>>,
     ws: ReadSignal<Option<web_sys::WebSocket>>,
     set_ws: WriteSignal<Option<web_sys::WebSocket>>,
     set_channels: WriteSignal<Vec<Channel>>,
@@ -119,13 +122,10 @@ fn connect_websocket(
         let _ = old_ws.close();
     }
 
-    // Watchdog state (#153): last_frame_at updated on every received frame,
-    // checked every 5s by the watchdog interval to detect zombie sockets.
-    // reconnect_attempt drives the exponential backoff schedule — it increments
-    // in onclose and resets to 0 on the first frame of a fresh socket.
-    let last_frame_at = std::rc::Rc::new(std::cell::Cell::new(js_sys::Date::now()));
-    let reconnect_attempt = std::rc::Rc::new(std::cell::Cell::new(0u32));
-    let last_reconnect_attempt_at = std::rc::Rc::new(std::cell::Cell::new(0.0_f64));
+    // Initialize last_frame_at to now — the onmessage handler will refresh it
+    // on every received frame, and the watchdog (in MixerPage) force-closes the
+    // socket if it falls more than 30s behind. #153
+    last_frame_at.set(js_sys::Date::now());
 
     let location = web_sys::window().unwrap().location();
     let host = location.host().unwrap_or_default();
@@ -777,11 +777,24 @@ pub fn MixerPage() -> impl IntoView {
         vis_closure.forget(); // Lives for component lifetime — one-time registration
     }
 
+    // Watchdog + backoff state (#153). Lives in MixerPage so it survives across
+    // reconnects — connect_websocket is called repeatedly by the reconnect loop
+    // below, so these cells must NOT live inside that helper.
+    // - last_frame_at: updated in onmessage, checked by the 5s watchdog
+    // - reconnect_attempt: incremented in onclose, reset in onmessage, drives backoff
+    // - last_reconnect_attempt_at: timestamp of last reconnect action, gates the
+    //   backoff schedule inside the reconnect closure below
+    let last_frame_at = std::rc::Rc::new(std::cell::Cell::new(js_sys::Date::now()));
+    let reconnect_attempt = std::rc::Rc::new(std::cell::Cell::new(0u32));
+    let last_reconnect_attempt_at = std::rc::Rc::new(std::cell::Cell::new(0.0_f64));
+
     // Connect WebSocket when member is known
     let ws_member_id = member_id.clone();
     let ws_closures_effect = ws_closures.clone();
     let ws_fail_count_effect = ws_fail_count.clone();
     let page_visible_effect = page_visible.clone();
+    let last_frame_at_effect = last_frame_at.clone();
+    let reconnect_attempt_effect = reconnect_attempt.clone();
     Effect::new(move |_| {
         let member = ws_member_id();
         if member.is_empty() {
@@ -790,6 +803,8 @@ pub fn MixerPage() -> impl IntoView {
 
         connect_websocket(
             &member,
+            last_frame_at_effect.clone(),
+            reconnect_attempt_effect.clone(),
             ws,
             set_ws,
             set_channels,
@@ -840,6 +855,7 @@ pub fn MixerPage() -> impl IntoView {
     let navigate_auth_fail = use_navigate();
     let reconnect_attempt_tick = reconnect_attempt.clone();
     let last_reconnect_attempt_at_tick = last_reconnect_attempt_at.clone();
+    let last_frame_at_tick = last_frame_at.clone();
     let reconnect_closure = Closure::wrap(Box::new(move || {
         // Exponential backoff gate: skip this tick if the scheduled delay
         // hasn't elapsed since the last reconnect attempt. #153
@@ -879,6 +895,8 @@ pub fn MixerPage() -> impl IntoView {
             last_reconnect_attempt_at_tick.set(now_ms);
             connect_websocket(
                 &member,
+                last_frame_at_tick.clone(),
+                reconnect_attempt_tick.clone(),
                 ws,
                 set_ws,
                 set_channels,

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -169,7 +169,10 @@ fn connect_websocket(
 
     // Handle incoming messages
     let onmessage = Closure::wrap(Box::new(move |e: web_sys::MessageEvent| {
-        // Any received frame counts as "alive" — refresh watchdog + reset backoff.
+        // Any received frame counts as "alive" — refresh watchdog and reset
+        // the reconnect backoff counter. This runs on every frame (not just
+        // the first); the Cell write is a no-op after the first reset, so
+        // the extra cost is negligible and the code stays branch-free.
         last_frame_at_msg.set(js_sys::Date::now());
         reconnect_attempt_msg.set(0);
         if let Some(text) = e.data().as_string() {
@@ -961,7 +964,11 @@ pub fn MixerPage() -> impl IntoView {
             return;
         }
         let now = js_sys::Date::now();
-        if crate::lifecycle::is_stale(last_frame_at_watch.get(), now, 30_000.0) {
+        if crate::lifecycle::is_stale(
+            last_frame_at_watch.get(),
+            now,
+            crate::lifecycle::WS_STALENESS_THRESHOLD_MS,
+        ) {
             web_sys::console::warn_1(
                 &"WS watchdog: no frames for >30s, force-closing socket".into(),
             );
@@ -973,7 +980,7 @@ pub fn MixerPage() -> impl IntoView {
         .unwrap()
         .set_interval_with_callback_and_timeout_and_arguments_0(
             watchdog_closure.as_ref().unchecked_ref(),
-            5_000,
+            crate::lifecycle::WS_WATCHDOG_INTERVAL_MS as i32,
         )
         .unwrap();
     watchdog_closure.forget();

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.141.0"
+version = "1.142.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.141.0",
+  "version": "1.142.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",


### PR DESCRIPTION
## Summary

- Replaces the default panic hook with a custom one that renders a full-screen red reload banner directly into `document.body` (bypassing the broken Leptos reactive graph) and fire-and-forgets a POST to a new public `/api/client-error` endpoint. Silent WASM panics now become visible in the on-disk tracing log.
- Adds a 5-second WebSocket watchdog that force-closes sockets which have not received any frame for more than 30 seconds. The existing `.disconnected-banner` then fires and the reconnect loop opens a new socket. Catches zombie sockets where `ready_state == OPEN` but no data flows.
- Replaces unbounded 2-second reconnect polling with an exponential backoff schedule (2s → 4s → 8s → 15s → 30s cap). Gentler on mobile radios and battery.
- New server endpoint `POST /api/client-error` logs reports via `tracing::warn!` with a grep-able `client_error` prefix. Body capped at 10 KiB via a per-route `DefaultBodyLimit`. Public (no auth) because panics may occur when auth itself is broken.

Fixes #153 — or, where the random freeze has a root cause we have not yet located, gives us the field-data tooling to pinpoint it in the next PR.

**Scope boundaries intentionally NOT in this PR (deferred until field data tells us whether they matter):**
- Talkback state-machine wedge fix
- iOS AudioContext gesture timing (user reported Android)
- WebSocket ping/pong protocol
- In-app error dashboard (user chose stdout-only logging)

## Test plan

- [x] 3 new Rust unit tests in `lifecycle.rs` for `backoff_delay_ms` and `is_stale` pure helpers
- [x] 3 new Rust unit tests in `lifecycle.rs` for `truncate_for_display` and `html_escape` (panic hook helpers)
- [x] 5 new Rust unit tests in `proxy.rs` for `ClientErrorReport` deserialization and the `client_error` handler
- [x] New post-deploy Playwright E2E `client-error-reporting.spec.ts` — POST from browser → 204 → PowerShell `Select-String` against the local rolling log file
- [x] New post-deploy Playwright E2E `client-error-reporting.spec.ts` — 12 KiB body → 413 Payload Too Large
- [x] Live verification on iem.lan: `curl POST /api/client-error` → 204, 11 KiB body → 413, log line grep confirms `client_error` and the marker message
- [ ] Manual: confirm no regressions in normal operation on Android PWA after deploy
- [ ] Field: wait for a real freeze report, check `Get-Content ~\AppData\Roaming\iem-mixer\logs\* | Select-String client_error` on iem.lan for new entries