### PR TITLE
fix: comprehensive disposal-race hardening (v1.143.0) (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,20 @@ jobs:
           fi
           echo "OK: No assume/skip patterns found in E2E tests"
 
-      - name: Ban unsafe signal writes inside spawn_local (#153)
+      - name: Self-test the disposal safety scanner (#153)
+        run: |
+          # Run the scanner's own unit tests first so a broken scanner
+          # can never silently pass a violation through.
+          python3 scripts/test_check_disposal_safety.py
+
+      - name: Ban unsafe signal writes inside danger zones (#153)
         run: |
           # Prevents the Leptos "reactive value has already been disposed"
-          # panic. Every set_*.set() / set_*.update() inside a spawn_local
-          # async block must use try_set / try_update so a mid-await dispose
-          # is handled silently instead of panicking.
+          # panic. Every set_*.set() / set_*.update() / .set_untracked() /
+          # .update_untracked() inside a spawn_local async block OR a
+          # Closure::wrap(Box::new(move ...)) block must use the try_*
+          # variant so a mid-await or post-dispose fire is handled silently
+          # instead of panicking.
           python3 scripts/check_disposal_safety.py
 
   # ============================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,14 @@ jobs:
           fi
           echo "OK: No assume/skip patterns found in E2E tests"
 
+      - name: Ban unsafe signal writes inside spawn_local (#153)
+        run: |
+          # Prevents the Leptos "reactive value has already been disposed"
+          # panic. Every set_*.set() / set_*.update() inside a spawn_local
+          # async block must use try_set / try_update so a mid-await dispose
+          # is handled silently instead of panicking.
+          python3 scripts/check_disposal_safety.py
+
   # ============================================================
   # LINT - Must pass before any builds
   # ============================================================

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.143.0 (2026-04-11)
+
+- **Fix**: comprehensive hardening of Leptos reactive-disposal races. v1.142.0's new WASM panic hook immediately surfaced a pre-existing bug class in production: `spawn_local` async tasks that wrote to signals after an `await` could panic with "tried to access a reactive value that has already been disposed" when the component unmounted mid-task. This release converts **54 signal-write sites** across 9 files (`mixer.rs`, `talk_button.rs`, `backup_section.rs`, `audio_player.rs`, `pin_change_modal.rs`, `preset_modal.rs`, `snapshot_modal.rs`, `landing.rs`, `login.rs`) to use `try_set` / `try_update`, which silently no-op on disposed signals instead of panicking. (#153)
+- **CI gate**: new `scripts/check_disposal_safety.py` check in the test-integrity job scans every `.rs` file in `iem-mixer/iem-ui/src/` and fails the build if any new `set_*.set()` / `set_*.update()` call appears inside a `spawn_local(async ...)` block without the `try_` prefix. Prevents this class of bug from ever coming back. Escape hatch via `// disposal-safe: <reason>` comment for the rare legitimate case. (#153)
+
 ### v1.142.0 (2026-04-11)
 
 - **Fix**: PWA self-healing — a new 5-second WebSocket watchdog force-closes sockets that have received no frames for more than 30 seconds. Catches "zombie sockets" where `readyState` is OPEN but no data flows. After force-close, the existing `.disconnected-banner` shows and the reconnect loop opens a new socket. Reconnect now uses exponential backoff (2s → 4s → 8s → 15s → 30s cap) instead of the previous unbounded 2-second polling — gentler on mobile radios and battery. (#153)

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.142.0"
+version = "1.143.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.142.0"
+version = "1.143.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.142.0"
+version = "1.143.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.142.0"
+version = "1.143.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/iem-ui/src/components/audio_player.rs
+++ b/iem-mixer/iem-ui/src/components/audio_player.rs
@@ -116,8 +116,11 @@ pub fn ListenButton(
         stats_closure_effect.borrow_mut().take();
 
         if current_state == ListenState::Listening {
+            // try_update defends against the disposal race where the 500ms
+            // tick fires between on_cleanup running and the interval actually
+            // being cancelled by the browser. #153
             let closure = Closure::wrap(Box::new(move || {
-                set_stream_stats.set(poll_stream_stats());
+                let _ = set_stream_stats.try_update(|v| *v = poll_stream_stats());
             }) as Box<dyn FnMut()>);
             let id = web_sys::window()
                 .unwrap()
@@ -362,6 +365,10 @@ fn start_listening(
     // always notify subscribers even when the value hasn't changed, which would
     // destroy and recreate the 500ms polling interval before it ever fires.
     let is_listening = std::cell::Cell::new(false);
+    // All signal writes in this WS callback use try_update — the WebSocket
+    // (and therefore this closure) can outlive the component if the socket is
+    // still open when ListenButton unmounts, and a late frame would panic on
+    // a disposed signal. See #153 follow-up.
     let on_message = Closure::wrap(Box::new(move |event: web_sys::MessageEvent| {
         // Binary message = Opus frame
         if let Ok(buf) = event.data().dyn_into::<js_sys::ArrayBuffer>() {
@@ -383,7 +390,7 @@ fn start_listening(
             frame_counter.set(count + 1);
             feed_opus_frame(&data);
             if !is_listening.get() {
-                set_state_msg.set(ListenState::Listening);
+                let _ = set_state_msg.try_update(|v| *v = ListenState::Listening);
                 is_listening.set(true);
             }
             return;
@@ -394,19 +401,19 @@ fn start_listening(
             if let Ok(msg) = serde_json::from_str::<iem_core::ServerMsg>(&text) {
                 if let iem_core::ServerMsg::AudioStatus { status, target } = msg {
                     if let Some(t) = target {
-                        set_listen_target.set(t);
+                        let _ = set_listen_target.try_update(|v| *v = t);
                     }
                     match status.as_str() {
                         "listening" => {
-                            set_state_msg.set(ListenState::Listening);
+                            let _ = set_state_msg.try_update(|v| *v = ListenState::Listening);
                             is_listening.set(true);
                         }
                         "no_source" => {
-                            set_state_msg.set(ListenState::NoSource);
+                            let _ = set_state_msg.try_update(|v| *v = ListenState::NoSource);
                             is_listening.set(false);
                         }
                         "stopped" => {
-                            set_state_msg.set(ListenState::Idle);
+                            let _ = set_state_msg.try_update(|v| *v = ListenState::Idle);
                             is_listening.set(false);
                         }
                         _ => {}
@@ -421,18 +428,20 @@ fn start_listening(
     // BEFORE calling socket.close(), so on_close sees the flag and stays Idle.
     let set_state_close = set_state;
     let set_ws_close = set_ws;
+    // All signal writes use try_update — same disposal-race reason as on_message. #153
     let on_close = Closure::wrap(Box::new(move |_: web_sys::Event| {
-        set_ws_close.set(None);
-        if intentional_stop.get_untracked() {
+        let _ = set_ws_close.try_update(|v| *v = None);
+        let intentional = intentional_stop.try_get_untracked().unwrap_or(false);
+        if intentional {
             // User clicked stop — stay in Idle, don't reconnect
             web_sys::console::log_1(&"[audio] WebSocket closed (user stopped)".into());
-            set_intentional_stop.set(false);
-            set_state_close.set(ListenState::Idle);
+            let _ = set_intentional_stop.try_update(|v| *v = false);
+            let _ = set_state_close.try_update(|v| *v = ListenState::Idle);
         } else {
             // Unexpected disconnect — auto-reconnect
             web_sys::console::log_1(&"[audio] WebSocket closed — will reconnect".into());
             // Don't stop audio player — keep AudioContext alive for seamless resume
-            set_state_close.set(ListenState::Reconnecting);
+            let _ = set_state_close.try_update(|v| *v = ListenState::Reconnecting);
         }
     }) as Box<dyn FnMut(_)>);
 
@@ -457,7 +466,10 @@ fn start_listening(
     on_close.forget();
     on_error.forget();
 
-    set_ws.set(Some(socket.clone()));
+    // try_update because start_listening is called from the reconnect
+    // interval closure which can outlive the component. If ListenButton is
+    // unmounted between reconnect attempts, set_ws is disposed here. #153
+    let _ = set_ws.try_update(|v| *v = Some(socket.clone()));
     // Do NOT set ListenState::Listening here — wait for the first binary frame
     // to arrive in on_message (line 149). Setting it prematurely makes the UI
     // show "Listening..." even when the WS fails to connect or ListenStart

--- a/iem-mixer/iem-ui/src/components/audio_player.rs
+++ b/iem-mixer/iem-ui/src/components/audio_player.rs
@@ -120,7 +120,7 @@ pub fn ListenButton(
             // tick fires between on_cleanup running and the interval actually
             // being cancelled by the browser. #153
             let closure = Closure::wrap(Box::new(move || {
-                let _ = set_stream_stats.try_update(|v| *v = poll_stream_stats());
+                let _ = set_stream_stats.try_set(poll_stream_stats());
             }) as Box<dyn FnMut()>);
             let id = web_sys::window()
                 .unwrap()
@@ -390,7 +390,7 @@ fn start_listening(
             frame_counter.set(count + 1);
             feed_opus_frame(&data);
             if !is_listening.get() {
-                let _ = set_state_msg.try_update(|v| *v = ListenState::Listening);
+                let _ = set_state_msg.try_set(ListenState::Listening);
                 is_listening.set(true);
             }
             return;
@@ -401,19 +401,19 @@ fn start_listening(
             if let Ok(msg) = serde_json::from_str::<iem_core::ServerMsg>(&text) {
                 if let iem_core::ServerMsg::AudioStatus { status, target } = msg {
                     if let Some(t) = target {
-                        let _ = set_listen_target.try_update(|v| *v = t);
+                        let _ = set_listen_target.try_set(t);
                     }
                     match status.as_str() {
                         "listening" => {
-                            let _ = set_state_msg.try_update(|v| *v = ListenState::Listening);
+                            let _ = set_state_msg.try_set(ListenState::Listening);
                             is_listening.set(true);
                         }
                         "no_source" => {
-                            let _ = set_state_msg.try_update(|v| *v = ListenState::NoSource);
+                            let _ = set_state_msg.try_set(ListenState::NoSource);
                             is_listening.set(false);
                         }
                         "stopped" => {
-                            let _ = set_state_msg.try_update(|v| *v = ListenState::Idle);
+                            let _ = set_state_msg.try_set(ListenState::Idle);
                             is_listening.set(false);
                         }
                         _ => {}
@@ -430,18 +430,18 @@ fn start_listening(
     let set_ws_close = set_ws;
     // All signal writes use try_update — same disposal-race reason as on_message. #153
     let on_close = Closure::wrap(Box::new(move |_: web_sys::Event| {
-        let _ = set_ws_close.try_update(|v| *v = None);
+        let _ = set_ws_close.try_set(None);
         let intentional = intentional_stop.try_get_untracked().unwrap_or(false);
         if intentional {
             // User clicked stop — stay in Idle, don't reconnect
             web_sys::console::log_1(&"[audio] WebSocket closed (user stopped)".into());
-            let _ = set_intentional_stop.try_update(|v| *v = false);
-            let _ = set_state_close.try_update(|v| *v = ListenState::Idle);
+            let _ = set_intentional_stop.try_set(false);
+            let _ = set_state_close.try_set(ListenState::Idle);
         } else {
             // Unexpected disconnect — auto-reconnect
             web_sys::console::log_1(&"[audio] WebSocket closed — will reconnect".into());
             // Don't stop audio player — keep AudioContext alive for seamless resume
-            let _ = set_state_close.try_update(|v| *v = ListenState::Reconnecting);
+            let _ = set_state_close.try_set(ListenState::Reconnecting);
         }
     }) as Box<dyn FnMut(_)>);
 
@@ -469,7 +469,7 @@ fn start_listening(
     // try_update because start_listening is called from the reconnect
     // interval closure which can outlive the component. If ListenButton is
     // unmounted between reconnect attempts, set_ws is disposed here. #153
-    let _ = set_ws.try_update(|v| *v = Some(socket.clone()));
+    let _ = set_ws.try_set(Some(socket.clone()));
     // Do NOT set ListenState::Listening here — wait for the first binary frame
     // to arrive in on_message (line 149). Setting it prematurely makes the UI
     // show "Listening..." even when the WS fails to connect or ListenStart

--- a/iem-mixer/iem-ui/src/components/backup_section.rs
+++ b/iem-mixer/iem-ui/src/components/backup_section.rs
@@ -28,10 +28,10 @@ pub fn BackupSection() -> impl IntoView {
             };
             match crate::api::list_backups(&token).await {
                 Ok(list) => {
-                    let _ = set_backups.try_update(|v| *v = list);
+                    let _ = set_backups.try_set(list);
                 }
                 Err(e) => {
-                    let _ = set_error.try_update(|v| *v = Some(e));
+                    let _ = set_error.try_set(Some(e));
                 }
             }
         });
@@ -98,14 +98,14 @@ pub fn BackupSection() -> impl IntoView {
                                             match crate::api::preview_restore(&token, &fname).await {
                                                 Ok(p) => {
                                                     let _ = set_preview
-                                                        .try_update(|v| *v = Some(p));
+                                                        .try_set(Some(p));
                                                 }
                                                 Err(e) => {
                                                     let _ = set_error
-                                                        .try_update(|v| *v = Some(e));
+                                                        .try_set(Some(e));
                                                 }
                                             }
-                                            let _ = set_loading.try_update(|v| *v = false);
+                                            let _ = set_loading.try_set(false);
                                         });
                                     }
                                 }
@@ -195,15 +195,15 @@ pub fn BackupSection() -> impl IntoView {
                                         match crate::api::apply_restore(&token, &fname).await {
                                             Ok(r) => {
                                                 let _ = set_result
-                                                    .try_update(|v| *v = Some(r));
-                                                let _ = set_preview.try_update(|v| *v = None);
+                                                    .try_set(Some(r));
+                                                let _ = set_preview.try_set(None);
                                             }
                                             Err(e) => {
                                                 let _ = set_error
-                                                    .try_update(|v| *v = Some(e));
+                                                    .try_set(Some(e));
                                             }
                                         }
-                                        let _ = set_restoring.try_update(|v| *v = false);
+                                        let _ = set_restoring.try_set(false);
                                     });
                                 }
                             }

--- a/iem-mixer/iem-ui/src/components/backup_section.rs
+++ b/iem-mixer/iem-ui/src/components/backup_section.rs
@@ -16,7 +16,10 @@ pub fn BackupSection() -> impl IntoView {
     let (error, set_error) = signal(Option::<String>::None);
     let (loading, set_loading) = signal(false);
 
-    // Load backups on mount
+    // Load backups on mount.
+    // Use try_update to guard signal writes against the disposal race — if the
+    // Settings modal closes while list_backups is awaiting, the resumed task
+    // would panic on a disposed signal. See #153 follow-up.
     {
         spawn_local(async move {
             let token = match crate::auth::get_auth() {
@@ -24,8 +27,12 @@ pub fn BackupSection() -> impl IntoView {
                 None => return,
             };
             match crate::api::list_backups(&token).await {
-                Ok(list) => set_backups.set(list),
-                Err(e) => set_error.set(Some(e)),
+                Ok(list) => {
+                    let _ = set_backups.try_update(|v| *v = list);
+                }
+                Err(e) => {
+                    let _ = set_error.try_update(|v| *v = Some(e));
+                }
             }
         });
     }
@@ -86,11 +93,19 @@ pub fn BackupSection() -> impl IntoView {
                                                 Some(a) => a.token,
                                                 None => return,
                                             };
+                                            // try_update guards against disposal race
+                                            // if the modal closes during preview_restore. #153
                                             match crate::api::preview_restore(&token, &fname).await {
-                                                Ok(p) => set_preview.set(Some(p)),
-                                                Err(e) => set_error.set(Some(e)),
+                                                Ok(p) => {
+                                                    let _ = set_preview
+                                                        .try_update(|v| *v = Some(p));
+                                                }
+                                                Err(e) => {
+                                                    let _ = set_error
+                                                        .try_update(|v| *v = Some(e));
+                                                }
                                             }
-                                            set_loading.set(false);
+                                            let _ = set_loading.try_update(|v| *v = false);
                                         });
                                     }
                                 }
@@ -145,17 +160,30 @@ pub fn BackupSection() -> impl IntoView {
                                     set_restoring.set(true);
                                     set_elapsed.set(0);
                                     set_error.set(None);
-                                    // Start elapsed timer (1s ticks)
+                                    // Start elapsed timer (1s ticks).
+                                    // Both the `restoring` read and the `set_elapsed` write
+                                    // use try_* so the loop terminates cleanly if the modal
+                                    // closes mid-restore instead of panicking. #153
                                     spawn_local(async move {
                                         loop {
                                             let promise = js_sys::Promise::new(&mut |resolve, _| {
                                                 web_sys::window().unwrap().set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 1000).unwrap();
                                             });
                                             wasm_bindgen_futures::JsFuture::from(promise).await.ok();
-                                            if !restoring.get_untracked() {
+                                            // If the signal is disposed, treat as "not restoring"
+                                            // and break out of the loop.
+                                            let still_restoring = restoring
+                                                .try_get_untracked()
+                                                .unwrap_or(false);
+                                            if !still_restoring {
                                                 break;
                                             }
-                                            set_elapsed.update(|e| *e += 1);
+                                            if set_elapsed
+                                                .try_update(|e| *e += 1)
+                                                .is_none()
+                                            {
+                                                break;
+                                            }
                                         }
                                     });
                                     // Start restore
@@ -166,12 +194,16 @@ pub fn BackupSection() -> impl IntoView {
                                         };
                                         match crate::api::apply_restore(&token, &fname).await {
                                             Ok(r) => {
-                                                set_result.set(Some(r));
-                                                set_preview.set(None);
+                                                let _ = set_result
+                                                    .try_update(|v| *v = Some(r));
+                                                let _ = set_preview.try_update(|v| *v = None);
                                             }
-                                            Err(e) => set_error.set(Some(e)),
+                                            Err(e) => {
+                                                let _ = set_error
+                                                    .try_update(|v| *v = Some(e));
+                                            }
                                         }
-                                        set_restoring.set(false);
+                                        let _ = set_restoring.try_update(|v| *v = false);
                                     });
                                 }
                             }

--- a/iem-mixer/iem-ui/src/components/eq_modal.rs
+++ b/iem-mixer/iem-ui/src/components/eq_modal.rs
@@ -1109,8 +1109,8 @@ fn EqSlider(
         let uc = Closure::wrap(Box::new(move |_ev: web_sys::MouseEvent| {
             *timeout_mu.borrow_mut() = None;
             let was_active = is_activated.get();
-            set_is_pending.set(false);
-            set_is_activated.set(false);
+            let _ = set_is_pending.try_set(false);
+            let _ = set_is_activated.try_set(false);
             *base_x_mu.borrow_mut() = None;
 
             if let Some(mc) = mm_cleanup.borrow_mut().take() {

--- a/iem-mixer/iem-ui/src/components/fader.rs
+++ b/iem-mixer/iem-ui/src/components/fader.rs
@@ -524,7 +524,7 @@ pub fn Fader(
                         Some(integer) => integer,
                         None => quantize(new_raw),
                     };
-                    set_local_value.set(new_value);
+                    let _ = set_local_value.try_set(new_value);
                     on_change.run(new_value);
                     *move_base_x_mm.borrow_mut() = Some(current_x);
                 }
@@ -538,7 +538,7 @@ pub fn Fader(
         // mouseup: cleanup listeners and state
         let uc = Closure::wrap(Box::new(move |_ev: web_sys::MouseEvent| {
             *timeout_handle_mu.borrow_mut() = None;
-            set_is_pending.set(false);
+            let _ = set_is_pending.try_set(false);
 
             if is_activated.get_untracked() {
                 if let Some(cb) = on_activate {
@@ -546,7 +546,7 @@ pub fn Fader(
                 }
             }
 
-            set_is_activated.set(false);
+            let _ = set_is_activated.try_set(false);
             *move_base_x_mu.borrow_mut() = None;
 
             if let Some(cb) = on_touch_state {

--- a/iem-mixer/iem-ui/src/components/pin_change_modal.rs
+++ b/iem-mixer/iem-ui/src/components/pin_change_modal.rs
@@ -129,22 +129,24 @@ pub fn PinChangeModal(
         } else {
             cur.clone()
         };
+        // try_update on every signal write — this task may outlive the
+        // modal if the user closes it while change_pin is awaiting. #153
         spawn_local(async move {
             match crate::api::change_pin(&old_pin, &new, &member).await {
                 Ok(()) => {
-                    set_success.set(true);
-                    set_loading.set(false);
+                    let _ = set_success.try_update(|v| *v = true);
+                    let _ = set_loading.try_update(|v| *v = false);
                 }
                 Err(e) => {
-                    set_error_msg.set(e);
-                    set_loading.set(false);
+                    let _ = set_error_msg.try_update(|v| *v = e);
+                    let _ = set_loading.try_update(|v| *v = false);
                     if !is_engineer {
-                        set_current_pin.set(String::new());
-                        set_active_field.set(0);
+                        let _ = set_current_pin.try_update(|v| *v = String::new());
+                        let _ = set_active_field.try_update(|v| *v = 0);
                     } else {
-                        set_new_pin.set(String::new());
-                        set_confirm_pin.set(String::new());
-                        set_active_field.set(1);
+                        let _ = set_new_pin.try_update(|v| *v = String::new());
+                        let _ = set_confirm_pin.try_update(|v| *v = String::new());
+                        let _ = set_active_field.try_update(|v| *v = 1);
                     }
                 }
             }

--- a/iem-mixer/iem-ui/src/components/pin_change_modal.rs
+++ b/iem-mixer/iem-ui/src/components/pin_change_modal.rs
@@ -134,19 +134,19 @@ pub fn PinChangeModal(
         spawn_local(async move {
             match crate::api::change_pin(&old_pin, &new, &member).await {
                 Ok(()) => {
-                    let _ = set_success.try_update(|v| *v = true);
-                    let _ = set_loading.try_update(|v| *v = false);
+                    let _ = set_success.try_set(true);
+                    let _ = set_loading.try_set(false);
                 }
                 Err(e) => {
-                    let _ = set_error_msg.try_update(|v| *v = e);
-                    let _ = set_loading.try_update(|v| *v = false);
+                    let _ = set_error_msg.try_set(e);
+                    let _ = set_loading.try_set(false);
                     if !is_engineer {
-                        let _ = set_current_pin.try_update(|v| *v = String::new());
-                        let _ = set_active_field.try_update(|v| *v = 0);
+                        let _ = set_current_pin.try_set(String::new());
+                        let _ = set_active_field.try_set(0);
                     } else {
-                        let _ = set_new_pin.try_update(|v| *v = String::new());
-                        let _ = set_confirm_pin.try_update(|v| *v = String::new());
-                        let _ = set_active_field.try_update(|v| *v = 1);
+                        let _ = set_new_pin.try_set(String::new());
+                        let _ = set_confirm_pin.try_set(String::new());
+                        let _ = set_active_field.try_set(1);
                     }
                 }
             }

--- a/iem-mixer/iem-ui/src/components/preset_modal.rs
+++ b/iem-mixer/iem-ui/src/components/preset_modal.rs
@@ -248,12 +248,12 @@ pub fn PresetModal(
             wasm_bindgen_futures::spawn_local(async move {
                 match fetch_presets(&member_id).await {
                     Ok(list) => {
-                        let _ = set_presets.try_update(|v| *v = list);
-                        let _ = set_loading.try_update(|v| *v = false);
+                        let _ = set_presets.try_set(list);
+                        let _ = set_loading.try_set(false);
                     }
                     Err(e) => {
-                        let _ = set_error.try_update(|v| *v = Some(e));
-                        let _ = set_loading.try_update(|v| *v = false);
+                        let _ = set_error.try_set(Some(e));
+                        let _ = set_loading.try_set(false);
                     }
                 }
             });
@@ -283,15 +283,15 @@ pub fn PresetModal(
                 Ok(()) => {
                     // Refresh list
                     if let Ok(list) = fetch_presets(&member_id).await {
-                        let _ = set_presets.try_update(|v| *v = list);
+                        let _ = set_presets.try_set(list);
                     }
-                    let _ = set_new_name.try_update(|v| *v = String::new());
+                    let _ = set_new_name.try_set(String::new());
                 }
                 Err(e) => {
-                    let _ = set_error.try_update(|v| *v = Some(e));
+                    let _ = set_error.try_set(Some(e));
                 }
             }
-            let _ = set_loading.try_update(|v| *v = false);
+            let _ = set_loading.try_set(false);
         });
     };
 
@@ -403,14 +403,14 @@ pub fn PresetModal(
                                                                 {
                                                                     Ok(()) => {
                                                                         if let Ok(list) = fetch_presets(&member_id).await {
-                                                                            let _ = set_presets.try_update(|v| *v = list);
+                                                                            let _ = set_presets.try_set(list);
                                                                         }
                                                                     }
                                                                     Err(e) => {
-                                                                        let _ = set_error.try_update(|v| *v = Some(e));
+                                                                        let _ = set_error.try_set(Some(e));
                                                                     }
                                                                 }
-                                                                let _ = set_loading.try_update(|v| *v = false);
+                                                                let _ = set_loading.try_set(false);
                                                             });
                                                         }
                                                     >
@@ -428,14 +428,14 @@ pub fn PresetModal(
                                                                 match delete_preset_api(&member_id, &name).await {
                                                                     Ok(()) => {
                                                                         if let Ok(list) = fetch_presets(&member_id).await {
-                                                                            let _ = set_presets.try_update(|v| *v = list);
+                                                                            let _ = set_presets.try_set(list);
                                                                         }
                                                                     }
                                                                     Err(e) => {
-                                                                        let _ = set_error.try_update(|v| *v = Some(e));
+                                                                        let _ = set_error.try_set(Some(e));
                                                                     }
                                                                 }
-                                                                let _ = set_loading.try_update(|v| *v = false);
+                                                                let _ = set_loading.try_set(false);
                                                             });
                                                         }
                                                     >

--- a/iem-mixer/iem-ui/src/components/preset_modal.rs
+++ b/iem-mixer/iem-ui/src/components/preset_modal.rs
@@ -243,15 +243,17 @@ pub fn PresetModal(
             set_loading.set(true);
             set_error.set(None);
 
+            // try_update on every signal write — modal can close during
+            // the fetch and dispose the surrounding scope. #153
             wasm_bindgen_futures::spawn_local(async move {
                 match fetch_presets(&member_id).await {
                     Ok(list) => {
-                        set_presets.set(list);
-                        set_loading.set(false);
+                        let _ = set_presets.try_update(|v| *v = list);
+                        let _ = set_loading.try_update(|v| *v = false);
                     }
                     Err(e) => {
-                        set_error.set(Some(e));
-                        set_loading.set(false);
+                        let _ = set_error.try_update(|v| *v = Some(e));
+                        let _ = set_loading.try_update(|v| *v = false);
                     }
                 }
             });
@@ -281,13 +283,15 @@ pub fn PresetModal(
                 Ok(()) => {
                     // Refresh list
                     if let Ok(list) = fetch_presets(&member_id).await {
-                        set_presets.set(list);
+                        let _ = set_presets.try_update(|v| *v = list);
                     }
-                    set_new_name.set(String::new());
+                    let _ = set_new_name.try_update(|v| *v = String::new());
                 }
-                Err(e) => set_error.set(Some(e)),
+                Err(e) => {
+                    let _ = set_error.try_update(|v| *v = Some(e));
+                }
             }
-            set_loading.set(false);
+            let _ = set_loading.try_update(|v| *v = false);
         });
     };
 
@@ -387,6 +391,7 @@ pub fn PresetModal(
                                                             set_loading.set(true);
 
                                                             wasm_bindgen_futures::spawn_local(async move {
+                                                                // try_update: modal can close mid-await. #153
                                                                 match update_preset_api(
                                                                     &member_id,
                                                                     &name,
@@ -398,12 +403,14 @@ pub fn PresetModal(
                                                                 {
                                                                     Ok(()) => {
                                                                         if let Ok(list) = fetch_presets(&member_id).await {
-                                                                            set_presets.set(list);
+                                                                            let _ = set_presets.try_update(|v| *v = list);
                                                                         }
                                                                     }
-                                                                    Err(e) => set_error.set(Some(e)),
+                                                                    Err(e) => {
+                                                                        let _ = set_error.try_update(|v| *v = Some(e));
+                                                                    }
                                                                 }
-                                                                set_loading.set(false);
+                                                                let _ = set_loading.try_update(|v| *v = false);
                                                             });
                                                         }
                                                     >
@@ -417,15 +424,18 @@ pub fn PresetModal(
                                                             set_loading.set(true);
 
                                                             wasm_bindgen_futures::spawn_local(async move {
+                                                                // try_update: modal can close mid-await. #153
                                                                 match delete_preset_api(&member_id, &name).await {
                                                                     Ok(()) => {
                                                                         if let Ok(list) = fetch_presets(&member_id).await {
-                                                                            set_presets.set(list);
+                                                                            let _ = set_presets.try_update(|v| *v = list);
                                                                         }
                                                                     }
-                                                                    Err(e) => set_error.set(Some(e)),
+                                                                    Err(e) => {
+                                                                        let _ = set_error.try_update(|v| *v = Some(e));
+                                                                    }
                                                                 }
-                                                                set_loading.set(false);
+                                                                let _ = set_loading.try_update(|v| *v = false);
                                                             });
                                                         }
                                                     >

--- a/iem-mixer/iem-ui/src/components/snapshot_modal.rs
+++ b/iem-mixer/iem-ui/src/components/snapshot_modal.rs
@@ -170,12 +170,12 @@ pub fn SnapshotModal(
             wasm_bindgen_futures::spawn_local(async move {
                 match fetch_snapshots(&member_id).await {
                     Ok(list) => {
-                        let _ = set_snapshots.try_update(|v| *v = list);
-                        let _ = set_loading.try_update(|v| *v = false);
+                        let _ = set_snapshots.try_set(list);
+                        let _ = set_loading.try_set(false);
                     }
                     Err(e) => {
-                        let _ = set_error.try_update(|v| *v = Some(e));
-                        let _ = set_loading.try_update(|v| *v = false);
+                        let _ = set_error.try_set(Some(e));
+                        let _ = set_loading.try_set(false);
                     }
                 }
             });
@@ -191,14 +191,14 @@ pub fn SnapshotModal(
             match create_snapshot(&member_id, Some("manual".to_string())).await {
                 Ok(()) => {
                     if let Ok(list) = fetch_snapshots(&member_id).await {
-                        let _ = set_snapshots.try_update(|v| *v = list);
+                        let _ = set_snapshots.try_set(list);
                     }
                 }
                 Err(e) => {
-                    let _ = set_error.try_update(|v| *v = Some(e));
+                    let _ = set_error.try_set(Some(e));
                 }
             }
-            let _ = set_loading.try_update(|v| *v = false);
+            let _ = set_loading.try_set(false);
         });
     };
 
@@ -273,9 +273,9 @@ pub fn SnapshotModal(
                                                                 wasm_bindgen_futures::spawn_local(async move {
                                                                     // try_update: modal can close mid-await. #153
                                                                     if let Err(e) = restore_snapshot(&member_id, timestamp).await {
-                                                                        let _ = set_error.try_update(|v| *v = Some(e));
+                                                                        let _ = set_error.try_set(Some(e));
                                                                     }
-                                                                    let _ = set_loading.try_update(|v| *v = false);
+                                                                    let _ = set_loading.try_set(false);
                                                                     on_close.run(());
                                                                 });
                                                             }
@@ -293,11 +293,11 @@ pub fn SnapshotModal(
                                                                 wasm_bindgen_futures::spawn_local(async move {
                                                                     // try_update: modal can close mid-await. #153
                                                                     if let Err(e) = delete_snapshot(&member_id, timestamp).await {
-                                                                        let _ = set_error.try_update(|v| *v = Some(e));
+                                                                        let _ = set_error.try_set(Some(e));
                                                                     } else if let Ok(list) = fetch_snapshots(&member_id).await {
-                                                                        let _ = set_snapshots.try_update(|v| *v = list);
+                                                                        let _ = set_snapshots.try_set(list);
                                                                     }
-                                                                    let _ = set_loading.try_update(|v| *v = false);
+                                                                    let _ = set_loading.try_set(false);
                                                                 });
                                                             }
                                                         }

--- a/iem-mixer/iem-ui/src/components/snapshot_modal.rs
+++ b/iem-mixer/iem-ui/src/components/snapshot_modal.rs
@@ -166,15 +166,16 @@ pub fn SnapshotModal(
             set_loading.set(true);
             set_error.set(None);
 
+            // try_update: modal can close mid-await. #153
             wasm_bindgen_futures::spawn_local(async move {
                 match fetch_snapshots(&member_id).await {
                     Ok(list) => {
-                        set_snapshots.set(list);
-                        set_loading.set(false);
+                        let _ = set_snapshots.try_update(|v| *v = list);
+                        let _ = set_loading.try_update(|v| *v = false);
                     }
                     Err(e) => {
-                        set_error.set(Some(e));
-                        set_loading.set(false);
+                        let _ = set_error.try_update(|v| *v = Some(e));
+                        let _ = set_loading.try_update(|v| *v = false);
                     }
                 }
             });
@@ -186,16 +187,18 @@ pub fn SnapshotModal(
         set_loading.set(true);
 
         wasm_bindgen_futures::spawn_local(async move {
+            // try_update: modal can close mid-await. #153
             match create_snapshot(&member_id, Some("manual".to_string())).await {
                 Ok(()) => {
-                    // Refresh list
                     if let Ok(list) = fetch_snapshots(&member_id).await {
-                        set_snapshots.set(list);
+                        let _ = set_snapshots.try_update(|v| *v = list);
                     }
                 }
-                Err(e) => set_error.set(Some(e)),
+                Err(e) => {
+                    let _ = set_error.try_update(|v| *v = Some(e));
+                }
             }
-            set_loading.set(false);
+            let _ = set_loading.try_update(|v| *v = false);
         });
     };
 
@@ -268,10 +271,11 @@ pub fn SnapshotModal(
                                                                 let member_id = member_id.clone();
                                                                 set_loading.set(true);
                                                                 wasm_bindgen_futures::spawn_local(async move {
+                                                                    // try_update: modal can close mid-await. #153
                                                                     if let Err(e) = restore_snapshot(&member_id, timestamp).await {
-                                                                        set_error.set(Some(e));
+                                                                        let _ = set_error.try_update(|v| *v = Some(e));
                                                                     }
-                                                                    set_loading.set(false);
+                                                                    let _ = set_loading.try_update(|v| *v = false);
                                                                     on_close.run(());
                                                                 });
                                                             }
@@ -287,12 +291,13 @@ pub fn SnapshotModal(
                                                                 let member_id = member_id.clone();
                                                                 set_loading.set(true);
                                                                 wasm_bindgen_futures::spawn_local(async move {
+                                                                    // try_update: modal can close mid-await. #153
                                                                     if let Err(e) = delete_snapshot(&member_id, timestamp).await {
-                                                                        set_error.set(Some(e));
+                                                                        let _ = set_error.try_update(|v| *v = Some(e));
                                                                     } else if let Ok(list) = fetch_snapshots(&member_id).await {
-                                                                        set_snapshots.set(list);
+                                                                        let _ = set_snapshots.try_update(|v| *v = list);
                                                                     }
-                                                                    set_loading.set(false);
+                                                                    let _ = set_loading.try_update(|v| *v = false);
                                                                 });
                                                             }
                                                         }

--- a/iem-mixer/iem-ui/src/components/talk_button.rs
+++ b/iem-mixer/iem-ui/src/components/talk_button.rs
@@ -154,7 +154,11 @@ pub fn TalkButton(
         }
 
         // Start mic capture (the WS handler will set state to Live on TalkAcquired,
-        // but we start capturing proactively to reduce latency)
+        // but we start capturing proactively to reduce latency).
+        //
+        // Use try_update on set_state to guard against disposal race — if the
+        // component unmounts while start_talkback is awaiting, writing to a
+        // disposed signal would panic. See #153 follow-up.
         if let Some(url) = ws_url_builder() {
             let set_state = set_state;
             wasm_bindgen_futures::spawn_local(async move {
@@ -165,7 +169,7 @@ pub fn TalkButton(
                     Err(e) => {
                         let msg = format!("{:?}", e);
                         if msg.contains("NotAllowedError") || msg.contains("Permission") {
-                            set_state.set(TalkState::MicBlocked);
+                            let _ = set_state.try_update(|v| *v = TalkState::MicBlocked);
                         } else {
                             web_sys::console::error_1(
                                 &format!("[talk] start failed: {}", msg).into(),

--- a/iem-mixer/iem-ui/src/components/talk_button.rs
+++ b/iem-mixer/iem-ui/src/components/talk_button.rs
@@ -169,7 +169,7 @@ pub fn TalkButton(
                     Err(e) => {
                         let msg = format!("{:?}", e);
                         if msg.contains("NotAllowedError") || msg.contains("Permission") {
-                            let _ = set_state.try_update(|v| *v = TalkState::MicBlocked);
+                            let _ = set_state.try_set(TalkState::MicBlocked);
                         } else {
                             web_sys::console::error_1(
                                 &format!("[talk] start failed: {}", msg).into(),

--- a/iem-mixer/iem-ui/src/pages/landing.rs
+++ b/iem-mixer/iem-ui/src/pages/landing.rs
@@ -61,10 +61,10 @@ pub fn LandingPage() -> impl IntoView {
         wasm_bindgen_futures::spawn_local(async move {
             match get_members_with_timeout().await {
                 Ok(members) => {
-                    let _ = set_state.try_update(|v| *v = LoadState::Loaded(members));
+                    let _ = set_state.try_set(LoadState::Loaded(members));
                 }
                 Err(e) => {
-                    let _ = set_state.try_update(|v| *v = LoadState::Error(e));
+                    let _ = set_state.try_set(LoadState::Error(e));
                 }
             }
         });

--- a/iem-mixer/iem-ui/src/pages/landing.rs
+++ b/iem-mixer/iem-ui/src/pages/landing.rs
@@ -56,11 +56,16 @@ pub fn LandingPage() -> impl IntoView {
         // Reset to loading state
         set_state.set(LoadState::Loading);
 
-        // Spawn async fetch
+        // Spawn async fetch. try_update: the landing page can unmount
+        // (user navigates) while get_members_with_timeout is awaiting. #153
         wasm_bindgen_futures::spawn_local(async move {
             match get_members_with_timeout().await {
-                Ok(members) => set_state.set(LoadState::Loaded(members)),
-                Err(e) => set_state.set(LoadState::Error(e)),
+                Ok(members) => {
+                    let _ = set_state.try_update(|v| *v = LoadState::Loaded(members));
+                }
+                Err(e) => {
+                    let _ = set_state.try_update(|v| *v = LoadState::Error(e));
+                }
             }
         });
     });

--- a/iem-mixer/iem-ui/src/pages/login.rs
+++ b/iem-mixer/iem-ui/src/pages/login.rs
@@ -55,6 +55,8 @@ pub fn LoginPage() -> impl IntoView {
 
             set_loading.set(true);
 
+            // try_update: the login page can unmount mid-await (e.g. the
+            // user hits the back button while the request is in flight). #153
             spawn_local(async move {
                 match api::login(&member_val, &pin_val).await {
                     Ok(auth) => {
@@ -62,9 +64,9 @@ pub fn LoginPage() -> impl IntoView {
                         nav(&next_val, Default::default());
                     }
                     Err(e) => {
-                        set_error.set(Some(e));
-                        set_pin.set(String::new());
-                        set_loading.set(false);
+                        let _ = set_error.try_update(|v| *v = Some(e));
+                        let _ = set_pin.try_update(|v| *v = String::new());
+                        let _ = set_loading.try_update(|v| *v = false);
                     }
                 }
             });

--- a/iem-mixer/iem-ui/src/pages/login.rs
+++ b/iem-mixer/iem-ui/src/pages/login.rs
@@ -64,9 +64,9 @@ pub fn LoginPage() -> impl IntoView {
                         nav(&next_val, Default::default());
                     }
                     Err(e) => {
-                        let _ = set_error.try_update(|v| *v = Some(e));
-                        let _ = set_pin.try_update(|v| *v = String::new());
-                        let _ = set_loading.try_update(|v| *v = false);
+                        let _ = set_error.try_set(Some(e));
+                        let _ = set_pin.try_set(String::new());
+                        let _ = set_loading.try_set(false);
                     }
                 }
             });

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -686,12 +686,15 @@ pub fn MixerPage() -> impl IntoView {
     let (has_photo, set_has_photo) = signal(false);
 
     // Check if member has photo on mount (#16)
+    // Use try_update to guard against disposal race — if the user navigates
+    // away while `get_members` is still in flight, the await resumes on a
+    // disposed signal and Leptos panics. See #153.
     {
         let mid = member_id();
         wasm_bindgen_futures::spawn_local(async move {
             if let Ok(members) = crate::api::get_members().await {
                 if let Some(m) = members.iter().find(|m| m.id == mid) {
-                    set_has_photo.set(m.has_photo);
+                    let _ = set_has_photo.try_update(|v| *v = m.has_photo);
                 }
             }
         });

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -191,32 +191,32 @@ fn connect_websocket(
                     } => {
                         // Successfully received data — reset failure counter
                         fail_count_msg.set(0);
-                        set_channels.update(|chs| {
+                        let _ = set_channels.try_update(|chs| {
                             let touched_snapshot: std::collections::HashMap<usize, bool> =
                                 touched.iter().map(|(k, v)| (*k, *v)).collect();
                             iem_core::merge_or_replace_channels(chs, new_chs, &touched_snapshot);
                         });
                         // Update global volume from initial state
                         if let Some(lvl) = global_level_db {
-                            set_global_level.set(lvl);
+                            let _ = set_global_level.try_set(lvl);
                         }
                         if let Some(muted) = global_muted {
-                            set_global_muted.set(muted);
+                            let _ = set_global_muted.try_set(muted);
                         }
                         if let Some(idx) = output_track_index {
-                            set_output_track_idx.set(Some(idx));
+                            let _ = set_output_track_idx.try_set(Some(idx));
                         }
                         if let Some(lvl) = stems_level_db {
-                            set_stems_level.set(lvl);
+                            let _ = set_stems_level.try_set(lvl);
                         }
                         if let Some(muted) = stems_muted {
-                            set_stems_muted.set(muted);
+                            let _ = set_stems_muted.try_set(muted);
                         }
                         if let Some(idx) = stems_bus_index {
-                            set_stems_bus_idx.set(Some(idx));
+                            let _ = set_stems_bus_idx.try_set(Some(idx));
                         }
-                        set_connected.set(conn);
-                        set_loading.set(false);
+                        let _ = set_connected.try_set(conn);
+                        let _ = set_loading.try_set(false);
                     }
                     iem_core::ServerMsg::Meters { meters: m } => {
                         if !page_visible.get() {
@@ -227,12 +227,12 @@ fn connect_websocket(
                         if now - last_meter_time.get() >= 50.0 {
                             last_meter_time.set(now);
                             // Merge delta meters into existing map (server sends only changed values)
-                            set_meters.update(|existing| {
+                            let _ = set_meters.try_update(|existing| {
                                 for (k, v) in m {
                                     existing.insert(k, v);
                                 }
                             });
-                            set_data_pulse.update(|v| *v = !*v);
+                            let _ = set_data_pulse.try_update(|v| *v = !*v);
                         }
                     }
                     iem_core::ServerMsg::ChannelUpdate {
@@ -242,7 +242,7 @@ fn connect_websocket(
                         pan,
                     } => {
                         if !touched.get(&track_index).copied().unwrap_or(false) {
-                            set_channels.update(|chs| {
+                            let _ = set_channels.try_update(|chs| {
                                 if let Some(ch) =
                                     chs.iter_mut().find(|c| c.track_index == track_index)
                                 {
@@ -255,25 +255,25 @@ fn connect_websocket(
                     }
                     iem_core::ServerMsg::GlobalVolumeUpdate { level_db, muted } => {
                         if !global_touched.get_untracked() {
-                            set_global_level.set(level_db);
-                            set_global_muted.set(muted);
+                            let _ = set_global_level.try_set(level_db);
+                            let _ = set_global_muted.try_set(muted);
                         }
                     }
                     iem_core::ServerMsg::StemsVolumeUpdate { level_db, muted } => {
                         if !stems_touched.get_untracked() {
-                            set_stems_level.set(level_db);
-                            set_stems_muted.set(muted);
+                            let _ = set_stems_level.try_set(level_db);
+                            let _ = set_stems_muted.try_set(muted);
                         }
                     }
                     iem_core::ServerMsg::ConnectionChanged { connected: conn } => {
-                        set_connected.set(conn);
+                        let _ = set_connected.try_set(conn);
                     }
                     iem_core::ServerMsg::CustomizationUpdate { pinned, hidden } => {
-                        set_pinned_channels.set(pinned);
-                        set_hidden_channels.set(hidden);
+                        let _ = set_pinned_channels.try_set(pinned);
+                        let _ = set_hidden_channels.try_set(hidden);
                     }
                     iem_core::ServerMsg::NetworkMode { mode } => {
-                        set_network_mode.set(mode);
+                        let _ = set_network_mode.try_set(mode);
                     }
                     iem_core::ServerMsg::SoloUpdate { soloed: new_solo } => {
                         let new_soloed: std::collections::HashSet<usize> =
@@ -283,7 +283,7 @@ fn connect_websocket(
                         if new_soloed != current {
                             if new_soloed.is_empty() && !current.is_empty() {
                                 // Remote un-soloed all: clear pre-solo mutes
-                                set_pre_solo_mutes.set(HashMap::new());
+                                let _ = set_pre_solo_mutes.try_set(HashMap::new());
                             } else if !new_soloed.is_empty() && current.is_empty() {
                                 // Remote entered solo: save current mute states for restore
                                 let chs = channels.get_untracked();
@@ -291,16 +291,16 @@ fn connect_websocket(
                                 for ch in &chs {
                                     saved.insert(ch.track_index, ch.muted);
                                 }
-                                set_pre_solo_mutes.set(saved);
+                                let _ = set_pre_solo_mutes.try_set(saved);
                             } else if !new_soloed.is_empty() && !current.is_empty() {
                                 // Remote exclusive switch: update local mute display (#131)
-                                set_channels.update(|chs| {
+                                let _ = set_channels.try_update(|chs| {
                                     for c in chs.iter_mut() {
                                         c.muted = !new_soloed.contains(&c.track_index);
                                     }
                                 });
                             }
-                            set_soloed.set(new_soloed);
+                            let _ = set_soloed.try_set(new_soloed);
                         }
                     }
                     iem_core::ServerMsg::AudioStatus { .. } => {
@@ -310,31 +310,33 @@ fn connect_websocket(
                         from_member,
                         from_name,
                     } => {
-                        set_alert_data.set(Some((from_member.clone(), from_name)));
-                        set_alert_active.set(true);
+                        let _ = set_alert_data.try_set(Some((from_member.clone(), from_name)));
+                        let _ = set_alert_active.try_set(true);
                     }
                     iem_core::ServerMsg::AlertCleared { member_id: cleared } => {
-                        set_alert_active.set(false);
+                        let _ = set_alert_active.try_set(false);
                         if let Some((ref m, _)) = alert_data.get_untracked() {
                             if *m == cleared {
-                                set_alert_data.set(None);
+                                let _ = set_alert_data.try_set(None);
                             }
                         }
                     }
                     iem_core::ServerMsg::ActiveAlerts { alerts } => {
                         if let Some(first) = alerts.first() {
-                            set_alert_data
-                                .set(Some((first.from_member.clone(), first.from_name.clone())));
+                            let _ = set_alert_data.try_set(Some((
+                                first.from_member.clone(),
+                                first.from_name.clone(),
+                            )));
                         }
                     }
                     iem_core::ServerMsg::TalkAcquired => {
-                        set_talk_state.set(TalkState::Live);
+                        let _ = set_talk_state.try_set(TalkState::Live);
                     }
                     iem_core::ServerMsg::TalkBusy { .. } => {
-                        set_talk_state.set(TalkState::InUse);
+                        let _ = set_talk_state.try_set(TalkState::InUse);
                     }
                     iem_core::ServerMsg::TalkReleased => {
-                        set_talk_state.set(TalkState::Idle);
+                        let _ = set_talk_state.try_set(TalkState::Idle);
                     }
                     iem_core::ServerMsg::EngineerTalking { active } => {
                         // Red page overlay on band member devices (no vibration)
@@ -349,14 +351,14 @@ fn connect_websocket(
                                 }
                             }
                         }
-                        set_engineer_talking.set(active);
+                        let _ = set_engineer_talking.try_set(active);
                     }
                     iem_core::ServerMsg::EqParams {
                         track_index: _,
                         track_name: _,
                         bands,
                     } => {
-                        set_eq_bands.set(
+                        let _ = set_eq_bands.try_set(
                             bands
                                 .into_iter()
                                 .map(|b| EqBandState {
@@ -371,7 +373,7 @@ fn connect_websocket(
                                 })
                                 .collect(),
                         );
-                        set_eq_loading.set(false);
+                        let _ = set_eq_loading.try_set(false);
                     }
                     iem_core::ServerMsg::EqParamsMulti { .. } => {
                         // Handled by preset modal (future integration)
@@ -383,10 +385,10 @@ fn connect_websocket(
                         limit_norm,
                         enabled,
                     } => {
-                        set_limiter_limit_db.set(limit_db);
-                        set_limiter_limit_norm.set(limit_norm);
-                        set_limiter_enabled.set(enabled);
-                        set_limiter_loading.set(false);
+                        let _ = set_limiter_limit_db.try_set(limit_db);
+                        let _ = set_limiter_limit_norm.try_set(limit_norm);
+                        let _ = set_limiter_enabled.try_set(enabled);
+                        let _ = set_limiter_loading.try_set(false);
                     }
                 }
             }
@@ -398,7 +400,7 @@ fn connect_websocket(
 
     // Handle close — mark disconnected and increment failure counter
     let onclose = Closure::wrap(Box::new(move |_: web_sys::CloseEvent| {
-        set_connected.set(false);
+        let _ = set_connected.try_set(false);
         fail_count_close.set(fail_count_close.get() + 1);
         reconnect_attempt_close.set(reconnect_attempt_close.get() + 1);
     }) as Box<dyn FnMut(web_sys::CloseEvent)>);
@@ -694,7 +696,7 @@ pub fn MixerPage() -> impl IntoView {
         wasm_bindgen_futures::spawn_local(async move {
             if let Ok(members) = crate::api::get_members().await {
                 if let Some(m) = members.iter().find(|m| m.id == mid) {
-                    let _ = set_has_photo.try_update(|v| *v = m.has_photo);
+                    let _ = set_has_photo.try_set(m.has_photo);
                 }
             }
         });

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.142.0"
+version = "1.143.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.142.0",
+  "version": "1.143.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",

--- a/scripts/check_disposal_safety.py
+++ b/scripts/check_disposal_safety.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""CI gate: forbid unsafe signal writes inside spawn_local async blocks.
+
+Motivation (#153): Leptos 0.7 panics with "tried to access a reactive value
+that has already been disposed" when `.set()` / `.update()` is called on a
+signal whose owning scope has been disposed. The most common trigger is a
+`spawn_local` task that awaits something and then writes a signal — the
+component can unmount while the task is suspended, so the resumed task
+writes to a disposed signal.
+
+This check scans every .rs file in iem-mixer/iem-ui/src/ and flags any line
+inside a `spawn_local(async move { ... })` or `spawn_local(async { ... })`
+block that writes to a Leptos signal via `.set(` or `.update(` without the
+`try_` prefix.
+
+Signals are identified by the convention used in Leptos's `signal()` return:
+the writer is named `set_<something>`. The regex is scoped tightly so it
+does NOT match web_sys method calls like `window.set_interval(...)`,
+`opts.set_body(...)`, or `socket.set_onclose(...)`.
+
+Allowed alternatives inside spawn_local:
+
+    let _ = set_x.try_set(value);
+    let _ = set_x.try_update(|v| *v = value);
+    let _ = set_x.try_update(|v| *v += 1);
+
+Escape hatch: append `// disposal-safe: <reason>` to the flagged line and the
+check will ignore it. Use this only when you can prove the write cannot race
+with dispose (e.g. immediately after a sync check that the owner is alive).
+
+Usage:
+    python3 scripts/check_disposal_safety.py
+
+Exits 0 if clean, 1 if any violation is found.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCAN_ROOT = REPO_ROOT / "iem-mixer" / "iem-ui" / "src"
+
+# Match identifiers that follow the Leptos writer convention (`set_*`)
+# calling `.set(` or `.update(` as a method. Word boundaries ensure we do
+# NOT match inside `try_set` / `try_update`, because the underscore in
+# `try_` is a word character and breaks the boundary.
+UNSAFE_WRITE = re.compile(
+    r"\bset_\w+\s*\.\s*\b(set|update)\b\s*\("
+)
+
+# Match spawn_local(async { or spawn_local(async move {
+SPAWN_LOCAL_START = re.compile(
+    r"\bspawn_local\s*\(\s*async(?:\s+move)?\s*\{"
+)
+
+ESCAPE_HATCH = "// disposal-safe:"
+
+
+def scan_file(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Return (line_number, line_text) for every violation in `path`."""
+    violations: list[tuple[int, str]] = []
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # Brace depth tracking for "inside spawn_local" state.
+    # When we enter a spawn_local block, we record how deep we are
+    # (relative to the surrounding scope) so we can tell when we leave.
+    spawn_depth_stack: list[int] = []
+    current_depth = 0
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        # Ignore pure line comments so a `// foo.set(bar)` in a doc comment
+        # doesn't trigger the gate.
+        if stripped.startswith("//"):
+            # still need to update brace depth from the rest of the file,
+            # but comments rarely contain braces that matter — skip.
+            continue
+
+        # Strip inline string literals (very naive: remove "..." spans) so
+        # regexes don't fire on string content.
+        stripped_code = _strip_strings(line)
+
+        # Count braces AFTER stripping strings so a `"foo{bar}"` literal
+        # doesn't confuse the depth tracker.
+        open_b = stripped_code.count("{")
+        close_b = stripped_code.count("}")
+
+        # Detect entering a spawn_local block.
+        # The brace opened by the spawn_local itself counts toward depth.
+        if SPAWN_LOCAL_START.search(stripped_code):
+            spawn_depth_stack.append(current_depth)
+
+        current_depth += open_b
+        current_depth -= close_b
+
+        # Pop any spawn_local frames whose block closed on this line.
+        while spawn_depth_stack and current_depth <= spawn_depth_stack[-1]:
+            spawn_depth_stack.pop()
+
+        # Inside a spawn_local block → flag unsafe writes.
+        if spawn_depth_stack:
+            if UNSAFE_WRITE.search(stripped_code) and ESCAPE_HATCH not in line:
+                violations.append((lineno, line.rstrip()))
+
+    return violations
+
+
+def _strip_strings(line: str) -> str:
+    """Remove double-quoted string contents from a line.
+
+    Very naive — does not handle escaped quotes, raw strings, or multi-line
+    strings. Good enough for scanning single-line .rs source where string
+    literals that would trigger the regex are rare. False negatives are
+    acceptable; the goal is to avoid false positives on string content.
+    """
+    result = []
+    in_string = False
+    for ch in line:
+        if ch == '"':
+            in_string = not in_string
+            result.append('"')
+        elif in_string:
+            result.append(" ")
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+def main() -> int:
+    if not SCAN_ROOT.is_dir():
+        print(f"::error::Scan root does not exist: {SCAN_ROOT}", file=sys.stderr)
+        return 2
+
+    all_violations: list[tuple[pathlib.Path, int, str]] = []
+    for rs_path in sorted(SCAN_ROOT.rglob("*.rs")):
+        for lineno, line in scan_file(rs_path):
+            rel = rs_path.relative_to(REPO_ROOT)
+            all_violations.append((rel, lineno, line))
+
+    if all_violations:
+        print(
+            "::error::Unsafe signal writes inside spawn_local blocks "
+            "(Leptos disposal race, #153):"
+        )
+        for rel, lineno, line in all_violations:
+            print(f"  {rel}:{lineno}: {line.strip()}")
+        print()
+        print("Fix: replace `.set(x)` with `.try_set(x)` or")
+        print("     `.try_update(|v| *v = x)`. Use `let _ =` to discard")
+        print("     the Option<...> result.")
+        print()
+        print("Escape hatch: append `// disposal-safe: <reason>` to the line")
+        print("if you can prove the write cannot race with scope disposal.")
+        return 1
+
+    print(
+        f"OK: no unsafe signal writes found inside spawn_local blocks "
+        f"({SCAN_ROOT.relative_to(REPO_ROOT)}/**/*.rs)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_disposal_safety.py
+++ b/scripts/check_disposal_safety.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""CI gate: forbid unsafe signal writes inside spawn_local async blocks.
+"""CI gate: forbid unsafe Leptos signal writes inside fire-and-forget closures.
 
 Motivation (#153): Leptos 0.7 panics with "tried to access a reactive value
-that has already been disposed" when `.set()` / `.update()` is called on a
-signal whose owning scope has been disposed. The most common trigger is a
-`spawn_local` task that awaits something and then writes a signal — the
-component can unmount while the task is suspended, so the resumed task
-writes to a disposed signal.
+that has already been disposed" when `.set()` / `.update()` (or their
+untracked variants) is called on a signal whose owning scope has been
+disposed. Two common triggers:
+
+1. A `spawn_local` task that awaits something and then writes a signal —
+   the component can unmount while the task is suspended, so the resumed
+   task writes to a disposed signal.
+
+2. A `Closure::wrap(Box::new(move |...| { ... }))` that gets handed to a
+   JS-side API (WebSocket.set_onmessage, setInterval, setTimeout,
+   set_onclick on a raw Element, addEventListener, etc.). These closures
+   live on the JS heap until their trampoline is invalidated or their
+   handler is replaced; they can fire AFTER the component's reactive scope
+   has already dropped, panicking when they write a signal.
 
 This check scans every .rs file in iem-mixer/iem-ui/src/ and flags any line
-inside a `spawn_local(async move { ... })` or `spawn_local(async { ... })`
-block that writes to a Leptos signal via `.set(` or `.update(` without the
+inside either of those danger zones that writes to a Leptos signal via
+`.set(`, `.update(`, `.set_untracked(`, or `.update_untracked(` without the
 `try_` prefix.
 
 Signals are identified by the convention used in Leptos's `signal()` return:
@@ -18,15 +27,18 @@ the writer is named `set_<something>`. The regex is scoped tightly so it
 does NOT match web_sys method calls like `window.set_interval(...)`,
 `opts.set_body(...)`, or `socket.set_onclose(...)`.
 
-Allowed alternatives inside spawn_local:
+Allowed alternatives:
 
     let _ = set_x.try_set(value);
     let _ = set_x.try_update(|v| *v = value);
     let _ = set_x.try_update(|v| *v += 1);
+    let _ = set_x.try_set_untracked(value);
+    let _ = set_x.try_update_untracked(|v| *v = value);
 
 Escape hatch: append `// disposal-safe: <reason>` to the flagged line and the
 check will ignore it. Use this only when you can prove the write cannot race
-with dispose (e.g. immediately after a sync check that the owner is alive).
+with dispose (e.g. the closure is attached to an event source that is
+provably torn down by the same scope that owns the signal).
 
 Usage:
     python3 scripts/check_disposal_safety.py
@@ -44,19 +56,45 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 SCAN_ROOT = REPO_ROOT / "iem-mixer" / "iem-ui" / "src"
 
 # Match identifiers that follow the Leptos writer convention (`set_*`)
-# calling `.set(` or `.update(` as a method. Word boundaries ensure we do
-# NOT match inside `try_set` / `try_update`, because the underscore in
-# `try_` is a word character and breaks the boundary.
+# calling `.set(`, `.update(`, `.set_untracked(`, or `.update_untracked(`
+# as a method. The `(?:_untracked)?` group covers both tracked and
+# untracked variants; word boundaries ensure we do NOT match inside
+# `try_set` / `try_update` / `try_set_untracked` / `try_update_untracked`,
+# because the underscore in `try_` is a word character and breaks the
+# boundary.
 UNSAFE_WRITE = re.compile(
-    r"\bset_\w+\s*\.\s*\b(set|update)\b\s*\("
+    r"\bset_\w+\s*\.\s*\b(?:set|update)(?:_untracked)?\b\s*\("
 )
 
-# Match spawn_local(async { or spawn_local(async move {
-SPAWN_LOCAL_START = re.compile(
+# Match the opening of a danger zone: either
+#   spawn_local(async { ...
+#   spawn_local(async move { ...
+#   Closure::wrap(Box::new(move || { ...
+#   Closure::wrap(Box::new(move |_args_| { ...
+#
+# Both kinds share a common property: the brace opened on this line
+# encloses code that may run AFTER the surrounding reactive scope has
+# been disposed. We use a single stack to track depth regardless of the
+# kind of danger zone.
+DANGER_ZONE_START = re.compile(
     r"\bspawn_local\s*\(\s*async(?:\s+move)?\s*\{"
+    r"|"
+    r"\bClosure::wrap\s*\(\s*Box::new\s*\(\s*move\s*\|[^|]*\|\s*\{"
 )
 
 ESCAPE_HATCH = "// disposal-safe:"
+
+# Rustfmt sometimes splits long `set_x.set(y)` statements across two lines:
+#     set_alert_data
+#         .set(Some(x));
+# MULTILINE_WRITER_TAIL matches the first line (ends with the writer name,
+# no method call yet), and MULTILINE_METHOD_HEAD matches the continuation
+# on the next line. Both must match (and neither half be individually
+# flagged by UNSAFE_WRITE) for the scanner to consider this a violation.
+MULTILINE_WRITER_TAIL = re.compile(r"\bset_\w+\s*$")
+MULTILINE_METHOD_HEAD = re.compile(
+    r"^\.\s*\b(?:set|update)(?:_untracked)?\b\s*\("
+)
 
 
 def scan_file(path: pathlib.Path) -> list[tuple[int, str]]:
@@ -65,10 +103,11 @@ def scan_file(path: pathlib.Path) -> list[tuple[int, str]]:
     text = path.read_text(encoding="utf-8")
     lines = text.splitlines()
 
-    # Brace depth tracking for "inside spawn_local" state.
-    # When we enter a spawn_local block, we record how deep we are
-    # (relative to the surrounding scope) so we can tell when we leave.
-    spawn_depth_stack: list[int] = []
+    # Brace depth tracking for "inside danger zone" state.
+    # When we enter a danger zone (spawn_local or Closure::wrap), we
+    # record how deep we are (relative to the surrounding scope) so we
+    # can tell when we leave. The stack supports nested zones.
+    danger_depth_stack: list[int] = []
     current_depth = 0
 
     for lineno, line in enumerate(lines, start=1):
@@ -90,22 +129,38 @@ def scan_file(path: pathlib.Path) -> list[tuple[int, str]]:
         open_b = stripped_code.count("{")
         close_b = stripped_code.count("}")
 
-        # Detect entering a spawn_local block.
-        # The brace opened by the spawn_local itself counts toward depth.
-        if SPAWN_LOCAL_START.search(stripped_code):
-            spawn_depth_stack.append(current_depth)
+        # Detect entering a danger zone. A single line may open more than
+        # one zone (e.g. a Closure::wrap inside a spawn_local), so count
+        # all matches.
+        for _ in DANGER_ZONE_START.finditer(stripped_code):
+            danger_depth_stack.append(current_depth)
 
         current_depth += open_b
         current_depth -= close_b
 
-        # Pop any spawn_local frames whose block closed on this line.
-        while spawn_depth_stack and current_depth <= spawn_depth_stack[-1]:
-            spawn_depth_stack.pop()
+        # Pop any danger zone frames whose block closed on this line.
+        while danger_depth_stack and current_depth <= danger_depth_stack[-1]:
+            danger_depth_stack.pop()
 
-        # Inside a spawn_local block → flag unsafe writes.
-        if spawn_depth_stack:
+        # Inside a danger zone → flag unsafe writes.
+        if danger_depth_stack:
             if UNSAFE_WRITE.search(stripped_code) and ESCAPE_HATCH not in line:
                 violations.append((lineno, line.rstrip()))
+            # Handle rustfmt-split writes: a line ending in `set_\w+` followed
+            # by a line that starts with `.set(` / `.update(` etc. The scanner
+            # otherwise misses these because both halves match no pattern on
+            # their own. We check the *current* line's end + the *next* line's
+            # start and flag it at the current line number so fixers land on
+            # the writer side.
+            if MULTILINE_WRITER_TAIL.search(stripped_code) and lineno < len(lines):
+                next_line = lines[lineno]  # lines is 0-indexed, lineno is 1-indexed
+                next_code = _strip_strings(next_line).lstrip()
+                if (
+                    MULTILINE_METHOD_HEAD.match(next_code)
+                    and ESCAPE_HATCH not in line
+                    and ESCAPE_HATCH not in next_line
+                ):
+                    violations.append((lineno, line.rstrip()))
 
     return violations
 

--- a/scripts/test_check_disposal_safety.py
+++ b/scripts/test_check_disposal_safety.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Unit tests for `scripts/check_disposal_safety.py`.
+
+Run: python3 scripts/test_check_disposal_safety.py
+
+The tests work on synthetic source snippets written to temporary files,
+so they do not touch the real iem-ui tree. Each test creates a file,
+runs `scan_file`, and asserts on the violations list.
+
+Why unit test a grep-shaped tool: the scanner's entire value proposition
+is that it has zero false positives on the existing safe patterns in the
+codebase (so developers trust it and don't hit "clippy fatigue") and zero
+false negatives on the known-bad patterns (so it actually prevents #153
+regressions). A fixture-based test suite pins both sides.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import traceback
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+# Import the module under test. This relies on check_disposal_safety.py
+# being importable — it is when run as a script by file path.
+import check_disposal_safety as cds  # noqa: E402
+
+
+def scan_src(src: str) -> list[tuple[int, str]]:
+    """Write `src` to a temp .rs file and run scan_file on it."""
+    with tempfile.NamedTemporaryFile("w", suffix=".rs", delete=False) as f:
+        f.write(src)
+        path = pathlib.Path(f.name)
+    try:
+        return cds.scan_file(path)
+    finally:
+        path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_failures: list[tuple[str, str]] = []
+_passed = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global _passed
+    if cond:
+        _passed += 1
+        print(f"  ok   {name}")
+    else:
+        _failures.append((name, detail))
+        print(f"  FAIL {name}{(' — ' + detail) if detail else ''}")
+
+
+def assert_violation_at(name: str, src: str, expected_line: int) -> None:
+    vs = scan_src(src)
+    lines = [ln for ln, _ in vs]
+    check(name, expected_line in lines, f"expected line {expected_line} in {lines}")
+
+
+def assert_no_violations(name: str, src: str) -> None:
+    vs = scan_src(src)
+    check(name, not vs, f"unexpected violations: {vs}")
+
+
+# ---------------------------------------------------------------------------
+# True positives — must be flagged
+# ---------------------------------------------------------------------------
+
+
+def test_set_inside_spawn_local_is_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        set_foo.set(1);
+    });
+}
+"""
+    assert_violation_at("set inside spawn_local is flagged", src, 4)
+
+
+def test_update_inside_spawn_local_is_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        set_foo.update(|v| *v = 1);
+    });
+}
+"""
+    assert_violation_at("update inside spawn_local is flagged", src, 4)
+
+
+def test_set_untracked_inside_spawn_local_is_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        set_foo.set_untracked(1);
+    });
+}
+"""
+    assert_violation_at("set_untracked inside spawn_local is flagged", src, 4)
+
+
+def test_update_untracked_inside_spawn_local_is_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        set_foo.update_untracked(|v| *v = 1);
+    });
+}
+"""
+    assert_violation_at("update_untracked inside spawn_local is flagged", src, 4)
+
+
+def test_set_inside_closure_wrap_is_flagged() -> None:
+    src = """
+fn f() {
+    let cb = Closure::wrap(Box::new(move |_: Event| {
+        set_state.set(Idle);
+    }) as Box<dyn FnMut(_)>);
+}
+"""
+    assert_violation_at("set inside Closure::wrap is flagged", src, 4)
+
+
+def test_rustfmt_split_multiline_is_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        set_alert_data
+            .set(Some(x));
+    });
+}
+"""
+    # The violation is reported at the WRITER line (first half), so fixers
+    # land on the variable name.
+    assert_violation_at("rustfmt-split multi-line is flagged", src, 4)
+
+
+def test_nested_danger_zones_are_tracked_independently() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        let cb = Closure::wrap(Box::new(move |_: Event| {
+            set_inner.set(1);
+        }));
+        set_outer.set(2);
+    });
+}
+"""
+    vs = scan_src(src)
+    lines = sorted(ln for ln, _ in vs)
+    check(
+        "both inner and outer writes flagged",
+        lines == [5, 7],
+        f"expected [5, 7], got {lines}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# True negatives — must NOT be flagged
+# ---------------------------------------------------------------------------
+
+
+def test_try_set_inside_spawn_local_is_ok() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        let _ = set_foo.try_set(1);
+    });
+}
+"""
+    assert_no_violations("try_set inside spawn_local is OK", src)
+
+
+def test_try_update_inside_spawn_local_is_ok() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        let _ = set_foo.try_update(|v| *v = 1);
+    });
+}
+"""
+    assert_no_violations("try_update inside spawn_local is OK", src)
+
+
+def test_set_outside_any_danger_zone_is_ok() -> None:
+    src = """
+fn f() {
+    set_foo.set(1);
+    set_bar.update(|v| *v += 1);
+}
+"""
+    assert_no_violations("set outside danger zone is OK", src)
+
+
+def test_web_sys_setters_are_not_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        window.set_interval_with_callback(cb, 1000);
+        opts.set_body(&value);
+        socket.set_onclose(Some(closure));
+        headers.set("content-type", "application/json");
+        element.set_onclick(handler);
+    });
+}
+"""
+    assert_no_violations(
+        "web_sys setters (set_interval, set_body, set_onclose, headers.set, set_onclick) are not flagged",
+        src,
+    )
+
+
+def test_disposal_safe_escape_hatch_respected() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        set_foo.set(1); // disposal-safe: only runs during mount
+    });
+}
+"""
+    assert_no_violations("// disposal-safe: escape hatch respected", src)
+
+
+def test_line_comment_set_is_not_flagged() -> None:
+    src = """
+fn f() {
+    spawn_local(async move {
+        // set_foo.set(1) — example in a comment
+        let _ = set_foo.try_set(1);
+    });
+}
+"""
+    assert_no_violations("signal write inside a // comment is not flagged", src)
+
+
+def test_string_literal_set_is_not_flagged() -> None:
+    src = '''
+fn f() {
+    spawn_local(async move {
+        let s = "set_foo.set(1)";
+        let _ = set_foo.try_set(1);
+    });
+}
+'''
+    assert_no_violations("signal write inside a string literal is not flagged", src)
+
+
+def test_set_in_plain_function_not_closure_not_flagged() -> None:
+    src = """
+fn f() {
+    fn helper() {
+        set_foo.set(1); // plain fn, not a closure
+    }
+    helper();
+}
+"""
+    assert_no_violations("set inside a plain nested fn is not flagged", src)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    print(f"Running {len(tests)} tests for check_disposal_safety.py")
+    for t in tests:
+        try:
+            t()
+        except Exception as e:
+            _failures.append((t.__name__, f"exception: {e}\n{traceback.format_exc()}"))
+            print(f"  CRASH {t.__name__}: {e}")
+    print()
+    print(f"Passed: {_passed}")
+    print(f"Failed: {len(_failures)}")
+    if _failures:
+        print()
+        print("Failures:")
+        for name, detail in _failures:
+            print(f"  {name}: {detail}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Follow-up to PR #163 (WASM panic hook for #153). The panic hook caught a real bug in production: the random freezes were caused by a pre-existing `tried to access a reactive value that has already been disposed` Leptos panic. This PR finds and fixes every instance and adds a CI gate so the bug class cannot come back.

**What changed**

- **54 signal-write sites across 9 files** converted from `signal.set(x)` / `signal.update(f)` to `let _ = signal.try_set(x)` / `let _ = signal.try_update(|v| *v = x)`. Every write is inside a `spawn_local(async move { ... })` block after an `.await`, or inside a WebSocket callback that can outlive its component. `try_*` variants return `Option<()>` and silently drop on a disposed signal instead of panicking.
- **New CI gate** at `scripts/check_disposal_safety.py`, invoked from the `test-integrity` job. Scans every `.rs` file in `iem-mixer/iem-ui/src/` and fails the build if any new `set_*.set()` or `set_*.update()` call appears inside a `spawn_local(async ...)` block without the `try_` prefix. Uses brace-depth tracking to only flag writes *inside* the block, and a tight regex that only matches Leptos writer names (`set_*`) so it does not false-positive on web_sys setters like `window.set_interval(...)` or `opts.set_body(...)`. Escape hatch: append `// disposal-safe: <reason>` to a line if you can prove the write is safe.
- **Version bump** 1.142.0 → 1.143.0 as the first commit on dev.

**Files touched**

| File | Fix count |
|---|---|
| `iem-mixer/iem-ui/src/pages/mixer.rs` | 1 |
| `iem-mixer/iem-ui/src/pages/landing.rs` | 2 |
| `iem-mixer/iem-ui/src/pages/login.rs` | 3 |
| `iem-mixer/iem-ui/src/components/talk_button.rs` | 1 |
| `iem-mixer/iem-ui/src/components/backup_section.rs` | 12 |
| `iem-mixer/iem-ui/src/components/audio_player.rs` | 15 |
| `iem-mixer/iem-ui/src/components/pin_change_modal.rs` | 9 |
| `iem-mixer/iem-ui/src/components/preset_modal.rs` | 14 |
| `iem-mixer/iem-ui/src/components/snapshot_modal.rs` | 12 |

The first four were found by hand from the #153 error evidence. The remaining five were found by the new scanner after I wrote it — proof that the scanner was necessary.

Fixes #153 (root cause, not just symptom). The panic hook from #163 remains as a safety net.

## Test plan

- [x] `python3 scripts/check_disposal_safety.py` passes locally and is clean
- [x] Test Integrity Check job green — the new CI gate runs and reports no violations
- [x] All 10 dev CI jobs green (after one rerun of a known-flaky meter animation test that races against real REAPER Meters messages)
- [x] Live deploy on 10.77.9.231 returns `{"version":"1.143.0","git_hash":"419f797","branch":"dev"}`
- [ ] Field verification — after merge, watch the rolling log at `%APPDATA%\iem-mixer\logs\iem-mixer.log.*` on iem.lan for `client_error` entries. A clean log over several days means the disposal races are actually gone.