### PR TITLE
feat: LIM button for all members (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.145.0 (2026-04-12)
+
+- **Feature**: LIM button now visible to all band members on their IEM Volume fader, not just the engineer — every member can control their own hearing protection threshold (#156)
+- **Security**: Server-side track-ownership validation ensures members can only control the limiter on their own output track; engineer retains control of all tracks (#156)
+
 ### v1.144.0 (2026-04-12)
 
 - **Fix**: Eliminated the "tried to access a reactive value that has already been disposed" error that could appear on the Android PWA when navigating back from the member mixer to the member selector. The underlying cause was plain Leptos `.set()` / `.update()` calls racing with component disposal when background intervals, WebSocket callbacks, and `spawn_local` async tasks kept firing during teardown. Production logs showed the panic arriving at ~1 Hz after the user was already on the landing page, because disposed-scope writes aborted the JS tick but did not stop the underlying intervals. (#153)

--- a/docs/superpowers/plans/2026-04-12-limiter-all-members.md
+++ b/docs/superpowers/plans/2026-04-12-limiter-all-members.md
@@ -1,0 +1,429 @@
+# Limiter Button for All Members — Implementation Plan (#156)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the LIM button visible and functional for all band members on their own IEM Volume fader, not just the engineer.
+
+**Architecture:** Remove the `is_engineer` UI guard on the LIM button (3 lines), add server-side track-ownership validation so members can only control their own limiter, update the existing E2E test that asserts members do NOT see LIM, and add a new test that confirms members CAN use it.
+
+**Tech Stack:** Rust (Leptos WASM frontend, Axum backend), Playwright E2E
+
+**Spec:** `docs/superpowers/specs/2026-04-12-limiter-all-members-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `iem-mixer/crates/iem-core/Cargo.toml` + 4 others + tauri.conf.json | Version bump 1.144.0 → 1.145.0 |
+| `iem-mixer/iem-ui/src/pages/mixer.rs:1832` | Remove `is_engineer.then()` wrapper on LIM button |
+| `iem-mixer/crates/iem-server/src/proxy.rs:1093,1097,1234-1282` | Pass `is_engineer` to `handle_ws`, add track-ownership check on limiter commands |
+| `iem-mixer/e2e/tests/live/limiter.spec.ts:95-131` | Flip "member does NOT see LIMIT" test to assert visibility + modal open |
+
+---
+
+## Task 1: Version Bump (1.144.0 → 1.145.0)
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-core/Cargo.toml:3`
+- Modify: `iem-mixer/Cargo.toml:12`
+- Modify: `iem-mixer/crates/iem-server/Cargo.toml:3`
+- Modify: `iem-mixer/iem-ui/Cargo.toml:3`
+- Modify: `iem-mixer/src-tauri/Cargo.toml:3`
+- Modify: `iem-mixer/src-tauri/tauri.conf.json`
+
+- [ ] **Step 1: Bump all version files**
+
+```bash
+sed -i 's/version = "1.144.0"/version = "1.145.0"/' \
+  iem-mixer/crates/iem-core/Cargo.toml \
+  iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml \
+  iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml
+sed -i 's/"version": "1.144.0"/"version": "1.145.0"/' iem-mixer/src-tauri/tauri.conf.json
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -c '1.145.0' iem-mixer/crates/iem-core/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+# Both should return 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/crates/iem-core/Cargo.toml iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+git commit -m "chore: bump version to 1.145.0"
+```
+
+---
+
+## Task 2: Server — Add track-ownership validation for limiter commands
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs:1093,1097-1101,1234-1282`
+
+Currently the three limiter WebSocket commands (`GetLimiterParams`, `SetLimiterParam`, `SetLimiterEnabled`) accept any `track_index` from any connected member without validation. The engineer connecting to another member's mixer can legitimately control that member's limiter, but a non-engineer member should only be able to control their own output track's limiter.
+
+- [ ] **Step 1: Pass `is_engineer` bool into `handle_ws`**
+
+In `proxy.rs`, the `ws_upgrade()` function (line 1093) calls `handle_ws` via the WebSocket upgrade. Add `claims.engineer` to the closure and function signature.
+
+Change line 1093:
+
+```rust
+// BEFORE:
+Ok(ws.on_upgrade(move |socket| handle_ws(socket, state, member_id, network_mode)))
+
+// AFTER:
+let is_engineer = claims.engineer;
+Ok(ws.on_upgrade(move |socket| handle_ws(socket, state, member_id, network_mode, is_engineer)))
+```
+
+Change the `handle_ws` signature at line 1097-1101:
+
+```rust
+// BEFORE:
+async fn handle_ws(
+    mut socket: axum::extract::ws::WebSocket,
+    state: AppState,
+    member_id: String,
+    network_mode: String,
+) {
+
+// AFTER:
+async fn handle_ws(
+    mut socket: axum::extract::ws::WebSocket,
+    state: AppState,
+    member_id: String,
+    network_mode: String,
+    is_engineer: bool,
+) {
+```
+
+- [ ] **Step 2: Add ownership check helper and guard limiter commands**
+
+Add an inline helper before the limiter command block (before line 1234). Then wrap each of the three limiter command handlers with the ownership check.
+
+Insert before line 1234 (above `// Handle Limiter commands`):
+
+```rust
+// Limiter ownership check: non-engineer members can only
+// control the limiter on their own output track (#156).
+let owns_limiter_track = |track_index: usize| -> bool {
+    if is_engineer {
+        return true;
+    }
+    // Check synchronously using try_read to avoid holding
+    // the lock across the await point.
+    if let Ok(cache) = state.mixer_cache.try_read() {
+        cache
+            .output_track_indices
+            .get(&member_id)
+            .map_or(false, |&idx| idx == track_index)
+    } else {
+        false // Lock contended — deny conservatively
+    }
+};
+```
+
+Then wrap each limiter command with the check. Replace lines 1235-1282 with:
+
+```rust
+// Handle Limiter commands (async EXTSTATE + ReaScript flow) (#72)
+if let iem_core::ClientMsg::GetLimiterParams { track_index } = cmd {
+    if owns_limiter_track(track_index) {
+        let state_clone = state.clone();
+        let member_clone = member_id.clone();
+        tokio::spawn(async move {
+            if let Some(lim_msg) =
+                handle_get_limiter_params(&state_clone, track_index).await
+            {
+                let _ = state_clone.event_tx.send((member_clone, lim_msg));
+            }
+        });
+    }
+    continue;
+}
+if let iem_core::ClientMsg::SetLimiterParam {
+    track_index,
+    ref param,
+    value,
+} = cmd
+{
+    if owns_limiter_track(track_index) {
+        let state_clone = state.clone();
+        let param_clone = param.clone();
+        tokio::spawn(async move {
+            handle_set_limiter_param(
+                &state_clone,
+                track_index,
+                &param_clone,
+                value,
+            )
+            .await;
+        });
+    }
+    continue;
+}
+if let iem_core::ClientMsg::SetLimiterEnabled {
+    track_index,
+    enabled,
+} = cmd
+{
+    if owns_limiter_track(track_index) {
+        let state_clone = state.clone();
+        tokio::spawn(async move {
+            handle_set_limiter_param(
+                &state_clone,
+                track_index,
+                "enabled",
+                if enabled { 1.0 } else { 0.0 },
+            )
+            .await;
+        });
+    }
+    continue;
+}
+```
+
+- [ ] **Step 3: Run `cargo fmt`**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+# Fix if needed:
+cd iem-mixer && cargo fmt --all
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iem-mixer/crates/iem-server/src/proxy.rs
+git commit -m "fix: add track-ownership validation for limiter WebSocket commands (#156)"
+```
+
+---
+
+## Task 3: UI — Remove engineer guard on LIM button
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/src/pages/mixer.rs:1832-1848`
+
+- [ ] **Step 1: Remove `is_engineer.then()` wrapper**
+
+Replace lines 1832-1848:
+
+```rust
+// BEFORE:
+{is_engineer.then(|| view! {
+    <button
+        class="limiter-btn-small"
+        on:click=move |_| {
+            if let Some(idx) = output_track_idx.get() {
+                let _ = set_limiter_loading.try_set(true);
+                let _ = set_limiter_open.try_set(Some((idx, "IEM VOL".to_string())));
+                ws_send(
+                    ws,
+                    &iem_core::ClientMsg::GetLimiterParams { track_index: idx },
+                );
+            }
+        }
+    >
+        "LIM"
+    </button>
+})}
+
+// AFTER:
+<button
+    class="limiter-btn-small"
+    on:click=move |_| {
+        if let Some(idx) = output_track_idx.get() {
+            let _ = set_limiter_loading.try_set(true);
+            let _ = set_limiter_open.try_set(Some((idx, "IEM VOL".to_string())));
+            ws_send(
+                ws,
+                &iem_core::ClientMsg::GetLimiterParams { track_index: idx },
+            );
+        }
+    }
+>
+    "LIM"
+</button>
+```
+
+- [ ] **Step 2: Remove `is_engineer` prop from `GlobalVolumeFader` function signature**
+
+The `is_engineer` parameter at line 1637 is now unused by `GlobalVolumeFader`. However, check if `is_engineer` is used elsewhere in the function body first.
+
+Search for `is_engineer` usage within the `GlobalVolumeFader` function (lines 1625-1860). If the LIM button was the ONLY use, remove:
+- The parameter `is_engineer: bool,` from the function signature (line 1637)
+- The `is_engineer=is_engineer` prop from the call site (line 1407)
+
+If `is_engineer` is used for something else in the function (e.g., the EQ button), keep it.
+
+- [ ] **Step 3: Run `cargo fmt`**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iem-mixer/iem-ui/src/pages/mixer.rs
+git commit -m "feat: show LIM button for all members, not just engineer (#156)"
+```
+
+---
+
+## Task 4: E2E Test — Update limiter tests for member access
+
+**Files:**
+- Modify: `iem-mixer/e2e/tests/live/limiter.spec.ts:95-131`
+
+The existing test at line 95 asserts `expect(count).toBe(0)` — that members do NOT see the LIM button. This must be flipped to assert they DO see it and can open the modal.
+
+- [ ] **Step 1: Replace the "member does NOT see LIMIT button" test**
+
+Replace lines 95-131 with a new test that verifies member access:
+
+```typescript
+test("member sees LIMIT button and can open modal", async ({ page }) => {
+    const consoleMessages: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        if (msg.text().includes("subscribe await failed")) return;
+        if (msg.text().includes("Push API in incognito")) return;
+        if (msg.text().includes("navigator.vibrate")) return;
+        if (msg.text().includes("closure invoked recursively")) return;
+        if (msg.text().includes("[vite]")) return;
+        if (msg.text().includes("favicon")) return;
+        if (msg.text().includes("integrity")) return;
+        if (msg.text().includes("WebSocket connection")) return;
+        consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+      }
+    });
+
+    // Login as regular member (petronela, PIN 7711)
+    await page.goto("/");
+    await loginAsMember(page, "petronela");
+    await page.goto("/petronela");
+
+    await waitForMixer(page);
+
+    await expect(page.locator(".channel").first()).toBeVisible({ timeout: 10000 });
+
+    // LIMIT button SHOULD be visible to regular members (#156)
+    const limitBtn = page.locator(".limiter-btn-small");
+    await expect(limitBtn.first()).toBeVisible({ timeout: 5000 });
+
+    // Click it and verify modal opens
+    await limitBtn.first().click();
+
+    const modal = page.locator(".limiter-modal");
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify modal has the MAX LEVEL slider
+    const sliders = page.locator(".limiter-slider-track");
+    await expect(sliders.first()).toBeVisible({ timeout: 3000 });
+    const sliderCount = await sliders.count();
+    expect(sliderCount).toBe(1);
+
+    // Close modal
+    const closeBtn = page.locator(".limiter-close-btn");
+    await closeBtn.click();
+    await expect(modal).not.toBeVisible({ timeout: 2000 });
+
+    expect(consoleMessages).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Update the test description comment at top of file**
+
+Replace the top-of-file docstring (lines 1-7) to reflect the new behavior:
+
+```typescript
+/**
+ * Limiter Tests — output bus limiter controls (#72, #156).
+ *
+ * These tests verify the LIMIT button visibility and modal behavior
+ * for both engineers and regular band members.
+ * The mixer page requires a REAPER connection to render channel strips.
+ */
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/e2e/tests/live/limiter.spec.ts
+git commit -m "test: update limiter E2E — member now sees and uses LIM button (#156)"
+```
+
+---
+
+## Task 5: Changelog + Push + Monitor CI
+
+**Files:**
+- Modify: `README.md` (changelog section)
+
+- [ ] **Step 1: Add changelog entry for v1.145.0**
+
+Add to the changelog section in README.md:
+
+```markdown
+### v1.145.0 (2026-04-12)
+- **Feature**: LIM button now visible to all band members on their IEM Volume fader, not just the engineer (#156)
+- **Security**: Server-side track-ownership validation ensures members can only control their own limiter
+```
+
+- [ ] **Step 2: Commit changelog**
+
+```bash
+git add README.md
+git commit -m "docs: changelog for v1.145.0 limiter for all members (#156)"
+```
+
+- [ ] **Step 3: Run `cargo fmt --all --check`**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+```
+
+- [ ] **Step 4: Push and monitor CI**
+
+```bash
+git push origin dev
+gh run list --limit 3
+# Monitor until ALL jobs reach terminal state
+```
+
+- [ ] **Step 5: If CI fails, investigate with `gh run view <id> --log-failed` and fix all issues in ONE commit**
+
+---
+
+## Task Dependencies
+
+```
+Task 1 (version bump)     ─── first
+Task 2 (server validation) ┐
+Task 3 (UI change)         ├── parallel, after Task 1
+Task 4 (E2E test update)   ┘
+Task 5 (changelog + push)  ─── last, after Tasks 2-4
+```
+
+Tasks 2, 3, and 4 are independent and can be done in parallel after Task 1.
+
+---
+
+## Verification
+
+After CI is green:
+
+1. **All CI jobs** pass (including deploy)
+2. **Post-deploy E2E** — limiter tests pass: engineer sees LIM, member sees LIM, modal opens for both
+3. **Server validation** — member can only control own limiter track (engineer can control any)

--- a/docs/superpowers/specs/2026-04-12-limiter-all-members-design.md
+++ b/docs/superpowers/specs/2026-04-12-limiter-all-members-design.md
@@ -1,0 +1,52 @@
+# Limiter Button for All Members — Design Spec (#156)
+
+## Problem
+
+The LIM button on the Global IEM Volume fader is engineer-only (`is_engineer.then(|| ...)` guard in `mixer.rs:1832`). Band members report they cannot see or access the limiter for their own inear output. The limiter controls hearing protection — every member should be able to control their own threshold.
+
+## Decision
+
+Members get full limiter control (ON/OFF + threshold) on their own inear output. No safety floor enforced by the engineer. The engineer retains the ability to control any member's limiter.
+
+## Changes
+
+### 1. UI: Remove engineer guard on LIM button
+
+**File:** `iem-mixer/iem-ui/src/pages/mixer.rs:1832`
+
+Remove the `is_engineer.then(|| ...)` wrapper around the LIM button in `GlobalVolumeFader`. The button renders for all authenticated users. `output_track_idx` is already populated for every member from the WebSocket `State` message, so no additional data flow changes are needed.
+
+### 2. Server: Add track-ownership validation for limiter commands
+
+**File:** `iem-mixer/crates/iem-server/src/proxy.rs`
+
+The three limiter WebSocket commands (`GetLimiterParams`, `SetLimiterParam`, `SetLimiterEnabled`) currently accept any `track_index` without validation. Add a scope check:
+
+- **Engineer:** Can get/set limiter params for any track (unchanged behavior).
+- **Member:** Can only get/set limiter params for their own output track. The member's output track index is available from `MixerCache::output_track_indices` keyed by `member_id`.
+- If a member sends a limiter command for a track that isn't theirs, ignore the command silently (no error response needed — this can only happen from a tampered client).
+
+### 3. E2E test: Non-engineer limiter access
+
+**File:** `iem-mixer/e2e/tests/live/limiter.spec.ts`
+
+Add a test that:
+1. Logs in as a non-engineer member (e.g., `petronela`)
+2. Navigates to their mixer page
+3. Asserts the LIM button is visible on the Global IEM Volume fader
+4. Clicks the LIM button
+5. Asserts the limiter modal opens with the MAX LEVEL slider visible
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `iem-mixer/iem-ui/src/pages/mixer.rs` | Remove `is_engineer` guard (~3 lines) |
+| `iem-mixer/crates/iem-server/src/proxy.rs` | Add track-ownership check for 3 limiter commands (~15 lines) |
+| `iem-mixer/e2e/tests/live/limiter.spec.ts` | Add non-engineer LIM visibility + modal test |
+
+## Out of scope
+
+- Engineer-enforced minimum threshold (user chose full member control)
+- Per-channel limiter buttons (only Global IEM Volume fader gets LIM)
+- Limiter activation logging (#145 — separate issue)

--- a/docs/superpowers/specs/2026-04-12-vibration-reliability-design.md
+++ b/docs/superpowers/specs/2026-04-12-vibration-reliability-design.md
@@ -1,0 +1,57 @@
+# Vibration Reliability Fix — Design Spec (#162)
+
+## Problem
+
+The engineer's phone vibration during SOS alerts is unreliable — sometimes vibrates, sometimes doesn't. The root cause is that `alert_toast.rs` uses `setInterval(1500ms)` + individual `navigator.vibrate(500)` calls. Mobile browsers (especially Android Chrome) aggressively throttle `setInterval` in background/minimized PWAs, and `navigator.vibrate()` is cancelled when the page becomes hidden per the Visibility API spec. When the user returns to the app, vibration never restarts because no `visibilitychange` listener re-triggers it.
+
+## Changes
+
+### 1. Replace interval-based vibration with pattern-based vibration
+
+**File:** `iem-mixer/iem-ui/src/components/alert_toast.rs`
+
+Replace the current approach:
+```
+setInterval(1500ms) → vibrate(500) on each tick
+```
+
+With:
+```
+navigator.vibrate([500, 1000, 500, 1000, ...]) — pattern repeated 30 times (~45s)
+setInterval(30000ms) → re-fire the full pattern (safety net for pattern expiry)
+```
+
+The browser handles pattern timing natively, which is resilient to JS timer throttling. The 30s refresh interval has ~20x fewer callbacks than the current 1.5s interval, making it far less susceptible to background throttling.
+
+### 2. Add visibilitychange listener for foreground recovery
+
+When the page becomes visible again (`document.visibilityState === "visible"`), immediately re-fire the vibration pattern if the alert is still active. This handles the "engineer switched apps and came back" case that currently leaves vibration dead.
+
+The listener must be added when the alert starts and removed when it clears, to avoid keeping a permanent global listener.
+
+### 3. Clean up on alert clear
+
+When the alert is dismissed:
+- Clear the 30s refresh interval
+- Call `navigator.vibrate(0)` to stop any in-progress pattern
+- Remove the `visibilitychange` listener
+
+### What stays the same
+
+- Service worker notification with vibrate pattern (`[500, 200, 500, 200, 500]`) — already reliable for backgrounded apps
+- Sound loop (`play_chime()` every 10s) — not affected by this change
+- Alert button haptic feedback (100ms on member's click) — not affected
+- Red page pulse overlay — not affected
+- WebSocket message flow — not affected
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `iem-mixer/iem-ui/src/components/alert_toast.rs` | Replace interval vibration with pattern + visibilitychange listener |
+
+## Out of scope
+
+- Sound loop reliability (not reported as broken)
+- Member-side haptic feedback (100ms on button click — works fine)
+- Service worker notification vibrate pattern (already reliable)

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.144.0"
+version = "1.145.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.144.0"
+version = "1.145.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.144.0"
+version = "1.145.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1246,7 +1246,7 @@ async fn handle_ws(
                                     cache
                                         .output_track_indices
                                         .get(&member_id)
-                                        .map_or(false, |&idx| idx == track_index)
+                                        .is_some_and(|&idx| idx == track_index)
                                 } else {
                                     false // Lock contended — deny conservatively
                                 }

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1090,7 +1090,8 @@ pub async fn ws_mixer(
         return Err((StatusCode::NOT_FOUND, Json(ApiError::not_found("Member"))));
     }
 
-    Ok(ws.on_upgrade(move |socket| handle_ws(socket, state, member_id, network_mode)))
+    let is_engineer = claims.engineer;
+    Ok(ws.on_upgrade(move |socket| handle_ws(socket, state, member_id, network_mode, is_engineer)))
 }
 
 /// Handle a WebSocket connection for a member
@@ -1099,6 +1100,7 @@ async fn handle_ws(
     state: AppState,
     member_id: String,
     network_mode: String,
+    is_engineer: bool,
 ) {
     use axum::extract::ws::Message;
     use iem_core::{ClientMsg, ServerMsg};
@@ -1232,16 +1234,38 @@ async fn handle_ws(
                             }
 
                             // Handle Limiter commands (async EXTSTATE + ReaScript flow) (#72)
+
+                            // Limiter ownership check: non-engineer members can only
+                            // control the limiter on their own output track (#156).
+                            let owns_limiter_track = |track_index: usize| -> bool {
+                                if is_engineer {
+                                    return true;
+                                }
+                                // Use try_read to avoid holding the lock across an await point.
+                                if let Ok(cache) = state.mixer_cache.try_read() {
+                                    cache
+                                        .output_track_indices
+                                        .get(&member_id)
+                                        .map_or(false, |&idx| idx == track_index)
+                                } else {
+                                    false // Lock contended — deny conservatively
+                                }
+                            };
+
                             if let iem_core::ClientMsg::GetLimiterParams { track_index } = cmd {
-                                let state_clone = state.clone();
-                                let member_clone = member_id.clone();
-                                tokio::spawn(async move {
-                                    if let Some(lim_msg) =
-                                        handle_get_limiter_params(&state_clone, track_index).await
-                                    {
-                                        let _ = state_clone.event_tx.send((member_clone, lim_msg));
-                                    }
-                                });
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    let member_clone = member_id.clone();
+                                    tokio::spawn(async move {
+                                        if let Some(lim_msg) =
+                                            handle_get_limiter_params(&state_clone, track_index)
+                                                .await
+                                        {
+                                            let _ =
+                                                state_clone.event_tx.send((member_clone, lim_msg));
+                                        }
+                                    });
+                                }
                                 continue;
                             }
                             if let iem_core::ClientMsg::SetLimiterParam {
@@ -1250,17 +1274,19 @@ async fn handle_ws(
                                 value,
                             } = cmd
                             {
-                                let state_clone = state.clone();
-                                let param_clone = param.clone();
-                                tokio::spawn(async move {
-                                    handle_set_limiter_param(
-                                        &state_clone,
-                                        track_index,
-                                        &param_clone,
-                                        value,
-                                    )
-                                    .await;
-                                });
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    let param_clone = param.clone();
+                                    tokio::spawn(async move {
+                                        handle_set_limiter_param(
+                                            &state_clone,
+                                            track_index,
+                                            &param_clone,
+                                            value,
+                                        )
+                                        .await;
+                                    });
+                                }
                                 continue;
                             }
                             if let iem_core::ClientMsg::SetLimiterEnabled {
@@ -1268,16 +1294,18 @@ async fn handle_ws(
                                 enabled,
                             } = cmd
                             {
-                                let state_clone = state.clone();
-                                tokio::spawn(async move {
-                                    handle_set_limiter_param(
-                                        &state_clone,
-                                        track_index,
-                                        "enabled",
-                                        if enabled { 1.0 } else { 0.0 },
-                                    )
-                                    .await;
-                                });
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    tokio::spawn(async move {
+                                        handle_set_limiter_param(
+                                            &state_clone,
+                                            track_index,
+                                            "enabled",
+                                            if enabled { 1.0 } else { 0.0 },
+                                        )
+                                        .await;
+                                    });
+                                }
                                 continue;
                             }
 

--- a/iem-mixer/e2e/tests/live/limiter.spec.ts
+++ b/iem-mixer/e2e/tests/live/limiter.spec.ts
@@ -1,9 +1,9 @@
 /**
- * Limiter Tests — output bus limiter controls (#72).
+ * Limiter Tests — output bus limiter controls (#72, #156).
  *
- * These tests verify the LIMIT button visibility and modal behavior.
- * The mixer page requires a REAPER connection to render channel strips,
- * so tests gracefully skip in CI when REAPER is not available.
+ * These tests verify the LIMIT button visibility and modal behavior
+ * for both engineers and regular band members.
+ * The mixer page requires a REAPER connection to render channel strips.
  */
 
 import { test, expect, Page } from "@playwright/test";
@@ -92,7 +92,7 @@ test.describe("Output Limiter — Issue #72", () => {
     expect(consoleMessages).toEqual([]);
   });
 
-  test("member does NOT see LIMIT button", async ({ page }) => {
+  test("member sees LIMIT button and can open modal", async ({ page }) => {
     const consoleMessages: string[] = [];
     page.on("console", (msg) => {
       if (msg.type() === "error" || msg.type() === "warning") {
@@ -108,24 +108,35 @@ test.describe("Output Limiter — Issue #72", () => {
       }
     });
 
-    const membersResp = await page.request.get("/api/members");
-    const members = await membersResp.json();
-    expect(members.length).toBeGreaterThan(0);
-    const member = members[0];
-
-    // Login as regular member
+    // Login as regular member (petronela, PIN 7711)
     await page.goto("/");
-    await loginAsMember(page, member.id);
-    await page.goto(`/${member.id}`);
+    await loginAsMember(page, "petronela");
+    await page.goto("/petronela");
 
     await waitForMixer(page);
 
     await expect(page.locator(".channel").first()).toBeVisible({ timeout: 10000 });
 
-    // LIMIT button should NOT be visible to regular members
+    // LIMIT button SHOULD be visible to regular members (#156)
     const limitBtn = page.locator(".limiter-btn-small");
-    const count = await limitBtn.count();
-    expect(count).toBe(0);
+    await expect(limitBtn.first()).toBeVisible({ timeout: 5000 });
+
+    // Click it and verify modal opens
+    await limitBtn.first().click();
+
+    const modal = page.locator(".limiter-modal");
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Verify modal has the MAX LEVEL slider
+    const sliders = page.locator(".limiter-slider-track");
+    await expect(sliders.first()).toBeVisible({ timeout: 3000 });
+    const sliderCount = await sliders.count();
+    expect(sliderCount).toBe(1);
+
+    // Close modal
+    const closeBtn = page.locator(".limiter-close-btn");
+    await closeBtn.click();
+    await expect(modal).not.toBeVisible({ timeout: 2000 });
 
     expect(consoleMessages).toEqual([]);
   });

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.144.0"
+version = "1.145.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -1404,7 +1404,6 @@ pub fn MixerPage() -> impl IntoView {
                                 set_eq_open=set_eq_open
                                 set_eq_bands=set_eq_bands
                                 set_eq_loading=set_eq_loading
-                                is_engineer=is_engineer
                                 set_limiter_open=set_limiter_open
                                 set_limiter_loading=set_limiter_loading
                             />
@@ -1634,7 +1633,6 @@ fn GlobalVolumeFader(
     set_eq_open: WriteSignal<Option<(usize, String)>>,
     set_eq_bands: WriteSignal<Vec<EqBandState>>,
     set_eq_loading: WriteSignal<bool>,
-    is_engineer: bool,
     set_limiter_open: WriteSignal<Option<(usize, String)>>,
     set_limiter_loading: WriteSignal<bool>,
 ) -> impl IntoView {
@@ -1829,23 +1827,21 @@ fn GlobalVolumeFader(
                 >
                     "EQ"
                 </button>
-                {is_engineer.then(|| view! {
-                    <button
-                        class="limiter-btn-small"
-                        on:click=move |_| {
-                            if let Some(idx) = output_track_idx.get() {
-                                let _ = set_limiter_loading.try_set(true);
-                                let _ = set_limiter_open.try_set(Some((idx, "IEM VOL".to_string())));
-                                ws_send(
-                                    ws,
-                                    &iem_core::ClientMsg::GetLimiterParams { track_index: idx },
-                                );
-                            }
+                <button
+                    class="limiter-btn-small"
+                    on:click=move |_| {
+                        if let Some(idx) = output_track_idx.get() {
+                            let _ = set_limiter_loading.try_set(true);
+                            let _ = set_limiter_open.try_set(Some((idx, "IEM VOL".to_string())));
+                            ws_send(
+                                ws,
+                                &iem_core::ClientMsg::GetLimiterParams { track_index: idx },
+                            );
                         }
-                    >
-                        "LIM"
-                    </button>
-                })}
+                    }
+                >
+                    "LIM"
+                </button>
                 <button
                     class=move || if muted.get() { "mute-btn on" } else { "mute-btn off" }
                     on:click=on_mute_click

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.144.0"
+version = "1.145.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.144.0",
+  "version": "1.145.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",


### PR DESCRIPTION
## Summary
- LIM button on IEM Volume fader now visible to all band members, not just the engineer — every member can control their own hearing protection threshold
- Server-side track-ownership validation ensures members can only control the limiter on their own output track; engineer retains control of all tracks
- E2E test updated: member (petronela) can see LIM button, open modal, verify slider

## Test plan
- [x] CI E2E: limiter tests pass (engineer sees LIM, member sees LIM + opens modal)
- [x] Post-deploy E2E: all live tests pass on iem.lan
- [x] All 10 CI jobs green including deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)