### PR TITLE
feat: limiter activation counter (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1115,6 +1115,14 @@ jobs:
           if errorlevel 1 (echo ERROR: Failed to deploy ReaScripts && exit /b 1)
           echo ReaScripts deployed
 
+      - name: Deploy JSFX to REAPER Effects
+        shell: cmd
+        run: |
+          if not exist "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\" mkdir "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\"
+          xcopy /Y scripts\reascripts\jsfx\MGA_JSLimiterST "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\"
+          if errorlevel 1 (echo ERROR: Failed to deploy JSFX && exit /b 1)
+          echo JSFX deployed
+
       - name: Register new ReaScripts in reaper-kb.ini
         shell: powershell
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1266,6 +1266,15 @@ jobs:
             exit 0
           }
 
+          # Force meter_bridge.lua to reload itself so code changes in the deployed
+          # file take effect (#145). Without this, the running instance keeps
+          # executing the code it was started with, ignoring the new file.
+          Invoke-WebRequest -Uri "http://iem.lan:8080/_/SET/EXTSTATE/REAPERIEM_METERS/reload_self/1" -UseBasicParsing -TimeoutSec 5 | Out-Null
+          Start-Sleep -Seconds 3  # let the running instance see the flag and exit
+          # Re-trigger meter_bridge so a fresh instance starts with the new code
+          Invoke-WebRequest -Uri "http://iem.lan:8080/_/_RS_REAPERIEM_METER_BRIDGE" -UseBasicParsing -TimeoutSec 5 | Out-Null
+          Start-Sleep -Seconds 2
+
           # meter_bridge.lua (running via defer) picks up EXTSTATE requests
           Invoke-WebRequest -Uri "http://iem.lan:8080/_/SET/EXTSTATE/reaperiem/register_scripts/setup_vban.lua|check_vban.lua|tone_generator.lua|setup_input_trim.lua|check_input_trim.lua|setup_input_eq.lua|read_eq_params.lua|set_eq_param.lua|reset_all_eq.lua|cleanup_mix_sends.lua|setup_mix_sends.lua|setup_talkback.lua|setup_output_limiter.lua|read_limiter_params.lua|set_limiter_param.lua|revert_project.lua" -UseBasicParsing -TimeoutSec 5 | Out-Null
           Start-Sleep -Seconds 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2186,6 +2186,46 @@ jobs:
             exit 1
           }
 
+      - name: Validate tone_generator action-ID hash (#145 pre-flight)
+        shell: powershell
+        run: |
+          # limiter-activity.spec.ts hardcodes the REAPER action ID hash that
+          # fires tone_generator.lua. If tone_generator.lua is ever moved or
+          # renamed, REAPER recomputes the hash and the test fails with
+          # "tone_generator did not run". Catch the drift here instead.
+          $expected = "RS39188b77eebdd3fcf32cb58063b41d1e3828b057"
+          $specFile = "iem-mixer/e2e/tests/live/limiter-activity.spec.ts"
+          if (-not (Test-Path $specFile)) {
+            Write-Host "::error::Spec file not found: $specFile"
+            exit 1
+          }
+          $specContent = Get-Content $specFile -Raw
+          if ($specContent -notmatch [regex]::Escape($expected)) {
+            Write-Host "::error::Hardcoded tone_generator hash drifted in $specFile. Expected $expected."
+            exit 1
+          }
+          $kbIni = "C:\Users\newlevel\AppData\Roaming\REAPER\reaper-kb.ini"
+          if (-not (Test-Path $kbIni)) {
+            Write-Host "::error::reaper-kb.ini not found on runner"
+            exit 1
+          }
+          $line = Select-String -Pattern "tone_generator\.lua" -Path $kbIni | Select-Object -First 1
+          if (-not $line) {
+            Write-Host "::error::tone_generator.lua not registered in reaper-kb.ini"
+            exit 1
+          }
+          if ($line.Line -match "(RS[0-9a-f]{40})") {
+            $actual = $matches[1]
+            if ($actual -ne $expected) {
+              Write-Host "::error::tone_generator hash drift: reaper-kb.ini has $actual, spec expects $expected. Update TONE_GEN_ACTION_ID in $specFile."
+              exit 1
+            }
+            Write-Host "tone_generator hash OK: $actual"
+          } else {
+            Write-Host "::error::Could not extract RS-hash from reaper-kb.ini line: $($line.Line)"
+            exit 1
+          }
+
       - name: Run post-deploy E2E tests
         shell: powershell
         working-directory: iem-mixer/e2e

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ### v1.149.0 (2026-04-13)
 
-- **Feature**: Per-inear-track limiter activation counter (#145). Open the LIM dialog on any channel to see how long that inear's safety limiter has been actively reducing gain since the last reset, plus a Reset button to zero it. Visible to engineer (any track) and to band members on their own track.
+- **Feature**: Per-inear-track limiter activation counter (#145). Open the LIM dialog on any channel to see how long that inear's safety limiter has been actively reducing gain (e.g. "21.3 sec limited" or "1 min 23 sec limited") since the last reset, plus a Reset button to zero it. Visible to engineer (any track) and to band members on their own track.
 - **Note**: Existing limiter instances pick up the new GR readout on next REAPER FX reload (next REAPER restart or project reload).
 
 ### v1.148.0 (2026-04-13)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.149.0 (2026-04-13)
+
+- **Feature**: Per-inear-track limiter activation counter (#145). Open the LIM dialog on any channel to see how long that inear's safety limiter has been actively reducing gain since the last reset, plus a Reset button to zero it. Visible to engineer (any track) and to band members on their own track.
+- **Note**: Existing limiter instances pick up the new GR readout on next REAPER FX reload (next REAPER restart or project reload).
+
 ### v1.148.0 (2026-04-13)
 
 - **Fix**: Talkback audio quality — eliminated "low quality / hanging / not fluent" by adding a 60 ms server-side jitter buffer with 20 ms drain loop, replacing the deprecated ScriptProcessor with an AudioWorklet that emits exact 20 ms Opus frames, and bumping Opus bitrate 64→96 kbps for voice. Addresses #154.

--- a/docs/superpowers/plans/2026-04-13-limiter-activation-counter.md
+++ b/docs/superpowers/plans/2026-04-13-limiter-activation-counter.md
@@ -1,0 +1,2000 @@
+# Limiter Activation Counter Implementation Plan (#145)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `Active: M:SS` line + `Reset` button inside the existing per-track Limiter modal that shows how long that inear's safety limiter has been actively reducing gain since the last reset.
+
+**Architecture:** Fork `MGA_JSLimiterST` JSFX to add a read-only slider5 mirroring the existing internal `gr_meter`. `meter_bridge.lua` polls slider5 each tick and accumulates active milliseconds per inear track when GR > 1 dB, writing per-track totals to a single EXTSTATE key. The server poller reads the totals into an in-memory `HashMap<usize, u64>` on `AppState`. The existing `handle_get_limiter_params` enriches its `ServerMsg::LimiterParams` reply with `active_seconds` from that HashMap. A new `ClientMsg::ResetLimiterActivity { track_index }` zeros both the server HashMap and the ReaScript-side accumulator (via an EXTSTATE round-trip so the next poller cycle does not re-overwrite the zero). UI changes are confined to `LimiterModal`.
+
+**Tech Stack:** JSFX (REAPER plugin DSL), Lua (ReaScript), Rust (axum + tokio + serde), Leptos WASM frontend, Playwright TypeScript E2E.
+
+**Spec:** `docs/superpowers/specs/2026-04-13-limiter-activation-counter-design.md`
+
+---
+
+## Hard constraints (per project CLAUDE.md + airuleset)
+
+- No local `cargo test/build/clippy/check` — blocked by hooks. Only `cargo fmt --all --check` runs locally. All test execution lives in CI.
+- All REAPER HTTP API URLs MUST use the `/_/` prefix.
+- The self-hosted runner is Windows — never use `shell: bash` for iem-lan jobs.
+- Every E2E spec must filter known noise and assert `consoleMessages` is empty.
+- Each fix/feature row in the completion-report E2E table must reference a real committed test file.
+- Last task presents the green PR URL and STOPS. Do NOT merge — wait for explicit user "merge it" / "approved" / "go ahead".
+
+---
+
+## File map
+
+### Created
+- `scripts/reascripts/jsfx/MGA_JSLimiterST` — local fork of upstream JSFX with slider5 added (deployed to `%APPDATA%\REAPER\Effects\loser\`)
+- `iem-mixer/e2e/tests/live/limiter-activity.spec.ts` — live E2E
+
+### Modified
+- `scripts/reascripts/meter_bridge.lua` — add limiter activity polling + reset handling
+- `iem-mixer/crates/iem-core/src/ws.rs:181-189` — extend `ServerMsg::LimiterParams` with `active_seconds`
+- `iem-mixer/crates/iem-core/src/ws.rs:46-102` — add `ClientMsg::ResetLimiterActivity` variant
+- `iem-mixer/crates/iem-server/src/lib.rs:99-154` — add `limiter_activity` field on `AppState`
+- `iem-mixer/crates/iem-server/src/lib.rs:207-249` — initialize the new field in `AppState::new`
+- `iem-mixer/crates/iem-server/src/poller.rs` — add EXTSTATE read for limiter activity totals each cycle
+- `iem-mixer/crates/iem-server/src/proxy.rs:1230-1311` — add `ResetLimiterActivity` handler in WS recv loop
+- `iem-mixer/crates/iem-server/src/proxy.rs:2505-2603` — enrich `handle_get_limiter_params` reply with `active_seconds`
+- `iem-mixer/iem-ui/src/components/limiter_modal.rs` — add `active_seconds` prop + on_reset callback + new row
+- `iem-mixer/iem-ui/src/pages/mixer.rs` — add active_seconds signal pair, populate from `LimiterParams` handler, pass to `LimiterModal`, wire `on_reset`
+- `iem-mixer/iem-ui/style.css` — minor styling for `.limiter-activity-row` and `.limiter-reset-btn`
+- `.github/workflows/ci.yml` — new "Deploy JSFX to REAPER Effects" step + register `jsfx/` path with the existing pre-deploy lint
+- `README.md` — v1.149.0 changelog entry
+- 5× `Cargo.toml` + `tauri.conf.json` — version bump 1.148.0 → 1.149.0
+
+---
+
+## Task 1: Version bump (FIRST commit, airuleset hard rule)
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-core/Cargo.toml`
+- Modify: `iem-mixer/Cargo.toml`
+- Modify: `iem-mixer/crates/iem-server/Cargo.toml`
+- Modify: `iem-mixer/iem-ui/Cargo.toml`
+- Modify: `iem-mixer/src-tauri/Cargo.toml`
+- Modify: `iem-mixer/src-tauri/tauri.conf.json`
+
+- [ ] **Step 1: Bump all Rust + Tauri version files**
+
+```bash
+sed -i 's/version = "1.148.0"/version = "1.149.0"/' \
+  iem-mixer/crates/iem-core/Cargo.toml \
+  iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml \
+  iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml
+sed -i 's/"version": "1.148.0"/"version": "1.149.0"/' iem-mixer/src-tauri/tauri.conf.json
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -c '1.149.0' iem-mixer/crates/iem-core/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+# Both must return 1.
+grep -r '1.148.0' iem-mixer/crates iem-mixer/src-tauri iem-mixer/Cargo.toml iem-mixer/iem-ui/Cargo.toml
+# Must return nothing.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/crates/iem-core/Cargo.toml iem-mixer/Cargo.toml \
+  iem-mixer/crates/iem-server/Cargo.toml iem-mixer/iem-ui/Cargo.toml \
+  iem-mixer/src-tauri/Cargo.toml iem-mixer/src-tauri/tauri.conf.json
+git commit -m "chore: bump version to 1.149.0 (#145)"
+```
+
+---
+
+## Task 2: Fork MGA_JSLimiterST with read-only GR slider
+
+**Files:**
+- Create: `scripts/reascripts/jsfx/MGA_JSLimiterST`
+
+The upstream plugin already computes `gr_meter` continuously and writes to REAPER's
+`ext_gr_meter` extension for the FX UI's own display. We add one read-only slider
+that mirrors the same value, so ReaScript can poll it via `TrackFX_GetParam(track, fx, 4)`
+(parameter index 4 = slider5, zero-based).
+
+The original file lives on iem.lan at `C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\MGA_JSLimiterST`. We copy it into the repo verbatim and add the two-line change.
+
+- [ ] **Step 1: Pull the upstream source from iem.lan into the repo**
+
+```bash
+mkdir -p scripts/reascripts/jsfx
+ssh newlevel@iem.lan 'powershell -Command "Get-Content C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\MGA_JSLimiterST"' \
+  > scripts/reascripts/jsfx/MGA_JSLimiterST
+```
+
+- [ ] **Step 2: Verify file size and shape**
+
+```bash
+wc -l scripts/reascripts/jsfx/MGA_JSLimiterST
+# Should be ~80-110 lines. If 0 or unreasonably large, the SSH redirect failed.
+grep -c '^slider' scripts/reascripts/jsfx/MGA_JSLimiterST
+# Should be 4 (slider1..slider4).
+grep -c 'ext_gr_meter' scripts/reascripts/jsfx/MGA_JSLimiterST
+# Should be >= 2 (one in @init, one in @block).
+```
+
+- [ ] **Step 3: Add slider5 declaration**
+
+Insert immediately after the existing `slider4:-0.1<-6,0,0.1>Ceiling` line:
+
+```jsfx
+slider5:0<-30,0,0.1>GR (dB read-only)
+```
+
+Apply with `Edit`:
+
+```
+old_string: slider4:-0.1<-6,0,0.1>Ceiling
+new_string: slider4:-0.1<-6,0,0.1>Ceiling
+slider5:0<-30,0,0.1>GR (dB read-only)
+```
+
+- [ ] **Step 4: Mirror ext_gr_meter into slider5 from @block**
+
+In the `@block` section, the upstream file has exactly one line:
+
+```jsfx
+ext_gr_meter = gr_meter > 0 ? log(gr_meter) * (20/log(10)) : -150;
+```
+
+Replace it with:
+
+```jsfx
+ext_gr_meter = gr_meter > 0 ? log(gr_meter) * (20/log(10)) : -150;
+slider5 = ext_gr_meter;
+sliderchange(slider5);
+```
+
+`sliderchange()` is the JSFX call that pushes the new slider value into REAPER's
+parameter automation system, making it readable from `TrackFX_GetParam`. The
+audio path (`gain`, `gainO`, `spl0 *= gain;`, etc.) is untouched.
+
+- [ ] **Step 5: Verify the edit**
+
+```bash
+grep -n '^slider\|^ext_gr_meter\|^slider5 =\|^sliderchange' scripts/reascripts/jsfx/MGA_JSLimiterST
+# Expected lines (in order):
+#   slider1:0<-30,0,0.1>Threshold (dB)
+#   slider2:200<0,500,1>Release (ms)
+#   slider3:75<0,100,1>Link Stereo (%)
+#   slider4:-0.1<-6,0,0.1>Ceiling
+#   slider5:0<-30,0,0.1>GR (dB read-only)
+#   ext_gr_meter = gr_meter > 0 ? log(gr_meter) * (20/log(10)) : -150;
+#   slider5 = ext_gr_meter;
+#   sliderchange(slider5);
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/reascripts/jsfx/MGA_JSLimiterST
+git commit -m "feat(jsfx): fork MGA_JSLimiterST to expose GR via slider5 (#145)"
+```
+
+---
+
+## Task 3: Deploy JSFX to REAPER Effects directory in CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:1110-1116` (insert new step immediately after "Deploy ReaScripts to REAPER")
+
+The existing step at line 1110 copies `scripts/reascripts/*.lua` to
+`%APPDATA%\REAPER\Scripts\reaperiem\`. We add a sibling step that copies the
+forked JSFX file to `%APPDATA%\REAPER\Effects\loser\`, replacing the upstream
+copy. Existing inserted instances pick up the new slider5 on next REAPER FX
+reload — acceptable degradation, documented in changelog.
+
+- [ ] **Step 1: Add the deploy step to ci.yml**
+
+Insert immediately AFTER the existing block ending at `echo ReaScripts deployed`
+(line 1116) and BEFORE the next step `Register new ReaScripts in reaper-kb.ini`:
+
+```yaml
+      - name: Deploy JSFX to REAPER Effects
+        shell: cmd
+        run: |
+          if not exist "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\" mkdir "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\"
+          xcopy /Y scripts\reascripts\jsfx\MGA_JSLimiterST "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\"
+          if errorlevel 1 (echo ERROR: Failed to deploy JSFX && exit /b 1)
+          echo JSFX deployed
+```
+
+Apply with `Edit`:
+
+```
+old_string:       - name: Deploy ReaScripts to REAPER
+        shell: cmd
+        run: |
+          if not exist "C:\Users\newlevel\AppData\Roaming\REAPER\Scripts\reaperiem\" mkdir "C:\Users\newlevel\AppData\Roaming\REAPER\Scripts\reaperiem\"
+          xcopy /Y scripts\reascripts\*.lua "C:\Users\newlevel\AppData\Roaming\REAPER\Scripts\reaperiem\"
+          if errorlevel 1 (echo ERROR: Failed to deploy ReaScripts && exit /b 1)
+          echo ReaScripts deployed
+
+      - name: Register new ReaScripts in reaper-kb.ini
+new_string:       - name: Deploy ReaScripts to REAPER
+        shell: cmd
+        run: |
+          if not exist "C:\Users\newlevel\AppData\Roaming\REAPER\Scripts\reaperiem\" mkdir "C:\Users\newlevel\AppData\Roaming\REAPER\Scripts\reaperiem\"
+          xcopy /Y scripts\reascripts\*.lua "C:\Users\newlevel\AppData\Roaming\REAPER\Scripts\reaperiem\"
+          if errorlevel 1 (echo ERROR: Failed to deploy ReaScripts && exit /b 1)
+          echo ReaScripts deployed
+
+      - name: Deploy JSFX to REAPER Effects
+        shell: cmd
+        run: |
+          if not exist "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\" mkdir "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\"
+          xcopy /Y scripts\reascripts\jsfx\MGA_JSLimiterST "C:\Users\newlevel\AppData\Roaming\REAPER\Effects\loser\"
+          if errorlevel 1 (echo ERROR: Failed to deploy JSFX && exit /b 1)
+          echo JSFX deployed
+
+      - name: Register new ReaScripts in reaper-kb.ini
+```
+
+- [ ] **Step 2: Verify the YAML edit (no syntax break)**
+
+```bash
+grep -n "Deploy JSFX to REAPER Effects\|Deploy ReaScripts to REAPER\|Register new ReaScripts" .github/workflows/ci.yml | head -5
+# Expected output:
+#   1110:      - name: Deploy ReaScripts to REAPER
+#   1118:      - name: Deploy JSFX to REAPER Effects
+#   1125:      - name: Register new ReaScripts in reaper-kb.ini
+# (Line numbers may shift; the order is what matters.)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: deploy MGA_JSLimiterST JSFX fork to REAPER Effects (#145)"
+```
+
+---
+
+## Task 4: meter_bridge.lua — accumulate per-track active milliseconds + handle reset
+
+**Files:**
+- Modify: `scripts/reascripts/meter_bridge.lua`
+
+Add a polling block inside `main()` (which already runs every defer tick). For
+every track whose name matches inear AND that has the JS limiter inserted, read
+slider5 via `TrackFX_GetParam(track, fx, 4)`. If value < -1.0 dB, accumulate the
+elapsed time since the previous tick into a per-track local table. Write all
+totals to `EXTSTATE REAPERIEM_LIMITER_ACTIVITY/totals` as `track_idx:active_ms;...`.
+
+Also read `EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset` each tick — if set to a
+track index string, zero that local entry and clear the EXTSTATE key. This is
+the round-trip that lets the server-side Reset button actually zero things
+durably (otherwise the next poller cycle would re-overwrite the server's zero
+with the still-large local total).
+
+- [ ] **Step 1: Add per-track activity state at the top of meter_bridge.lua**
+
+Insert AFTER the existing `local RUNNING_KEY = "bridge_running"` line (around line 22):
+
+```lua
+
+-- Limiter activity tracking (#145)
+-- Per-inear-track cumulative active milliseconds where GR < -1.0 dB.
+-- Resets only when EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset is set to that
+-- track index (the iem-mixer server writes this in response to the user
+-- clicking Reset in the LimiterModal).
+local LIMITER_SECTION = "REAPERIEM_LIMITER_ACTIVITY"
+local LIMITER_TOTALS_KEY = "totals"
+local LIMITER_RESET_KEY = "reset"
+local LIMITER_GR_THRESHOLD_DB = -1.0  -- counts as "active" when slider5 < this
+local LIMITER_FX_NAME_PATTERN = "MGA_JSLimiter"
+
+-- Per-track active_ms accumulator: map<track_index_1based, integer_ms>
+local limiter_active_ms = {}
+-- Tick timestamp tracking (so we attribute exact wall delta, not fixed assumed dt)
+local last_tick_time = nil
+```
+
+Apply with `Edit`:
+
+```
+old_string: local RUNNING_KEY = "bridge_running"
+new_string: local RUNNING_KEY = "bridge_running"
+
+-- Limiter activity tracking (#145)
+-- Per-inear-track cumulative active milliseconds where GR < -1.0 dB.
+-- Resets only when EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset is set to that
+-- track index (the iem-mixer server writes this in response to the user
+-- clicking Reset in the LimiterModal).
+local LIMITER_SECTION = "REAPERIEM_LIMITER_ACTIVITY"
+local LIMITER_TOTALS_KEY = "totals"
+local LIMITER_RESET_KEY = "reset"
+local LIMITER_GR_THRESHOLD_DB = -1.0  -- counts as "active" when slider5 < this
+local LIMITER_FX_NAME_PATTERN = "MGA_JSLimiter"
+
+-- Per-track active_ms accumulator: map<track_index_1based, integer_ms>
+local limiter_active_ms = {}
+-- Tick timestamp tracking (so we attribute exact wall delta, not fixed assumed dt)
+local last_tick_time = nil
+```
+
+- [ ] **Step 2: Add the polling block inside main()**
+
+The existing `main()` body iterates tracks 0..track_count-1 building the meter
+parts table. AFTER the meter loop completes (after `parts[#parts + 1] = ...`
+loop ends, before `reaper.SetExtState(SECTION, KEY, ...)`), add the limiter
+activity loop. We use `time_precise()` so a defer hiccup is not counted as
+activation time.
+
+Insert AFTER the existing `for i = 0, track_count - 1 do ... end` block (the
+one that builds `parts`) and BEFORE `reaper.SetExtState(SECTION, KEY, table.concat(parts, ";"), false)`:
+
+```lua
+
+  -- Limiter activity polling (#145).
+  -- For every track that has our JS limiter, read slider5 (GR readout in dB,
+  -- written by the JSFX from ext_gr_meter via sliderchange()), accumulate
+  -- elapsed wall time into limiter_active_ms whenever slider5 < threshold.
+  local now = reaper.time_precise()
+  local dt_ms = 0
+  if last_tick_time then
+    dt_ms = math.floor((now - last_tick_time) * 1000.0 + 0.5)
+    -- Clamp huge deltas (defer pause, REAPER backgrounded) so a 30 s pause
+    -- doesn't show up as 30 s of limiter activity.
+    if dt_ms > 250 then dt_ms = 0 end
+  end
+  last_tick_time = now
+
+  -- Reset request handling — server writes track index here when user clicks Reset.
+  local reset_request = reaper.GetExtState(LIMITER_SECTION, LIMITER_RESET_KEY)
+  if reset_request ~= "" then
+    local reset_idx = tonumber(reset_request)
+    if reset_idx then
+      limiter_active_ms[reset_idx] = 0
+    end
+    reaper.SetExtState(LIMITER_SECTION, LIMITER_RESET_KEY, "", false)
+  end
+
+  local lim_parts = {}
+  for i = 0, track_count - 1 do
+    local track = reaper.GetTrack(0, i)
+    if track then
+      local fx_count = reaper.TrackFX_GetCount(track)
+      local fx_idx = -1
+      for f = 0, fx_count - 1 do
+        local _, fx_name = reaper.TrackFX_GetFXName(track, f)
+        if fx_name and fx_name:find(LIMITER_FX_NAME_PATTERN, 1, true) then
+          fx_idx = f
+          break
+        end
+      end
+      if fx_idx >= 0 then
+        local track_idx = i + 1  -- 1-based to match meter convention
+        local gr_db = reaper.TrackFX_GetParam(track, fx_idx, 4)  -- slider5
+        if dt_ms > 0 and gr_db < LIMITER_GR_THRESHOLD_DB then
+          limiter_active_ms[track_idx] = (limiter_active_ms[track_idx] or 0) + dt_ms
+        end
+        local total = limiter_active_ms[track_idx] or 0
+        lim_parts[#lim_parts + 1] = track_idx .. ":" .. total
+      end
+    end
+  end
+  reaper.SetExtState(LIMITER_SECTION, LIMITER_TOTALS_KEY, table.concat(lim_parts, ";"), false)
+```
+
+Apply with `Edit`. The `old_string` is the existing line that writes the meter
+EXTSTATE; `new_string` inserts the limiter block immediately before it:
+
+```
+old_string:   reaper.SetExtState(SECTION, KEY, table.concat(parts, ";"), false)
+
+  -- Dynamic script registration via EXTSTATE (no REAPER restart needed)
+new_string:
+  -- Limiter activity polling (#145).
+  -- For every track that has our JS limiter, read slider5 (GR readout in dB,
+  -- written by the JSFX from ext_gr_meter via sliderchange()), accumulate
+  -- elapsed wall time into limiter_active_ms whenever slider5 < threshold.
+  local now = reaper.time_precise()
+  local dt_ms = 0
+  if last_tick_time then
+    dt_ms = math.floor((now - last_tick_time) * 1000.0 + 0.5)
+    -- Clamp huge deltas (defer pause, REAPER backgrounded) so a 30 s pause
+    -- doesn't show up as 30 s of limiter activity.
+    if dt_ms > 250 then dt_ms = 0 end
+  end
+  last_tick_time = now
+
+  -- Reset request handling — server writes track index here when user clicks Reset.
+  local reset_request = reaper.GetExtState(LIMITER_SECTION, LIMITER_RESET_KEY)
+  if reset_request ~= "" then
+    local reset_idx = tonumber(reset_request)
+    if reset_idx then
+      limiter_active_ms[reset_idx] = 0
+    end
+    reaper.SetExtState(LIMITER_SECTION, LIMITER_RESET_KEY, "", false)
+  end
+
+  local lim_parts = {}
+  for i = 0, track_count - 1 do
+    local track = reaper.GetTrack(0, i)
+    if track then
+      local fx_count = reaper.TrackFX_GetCount(track)
+      local fx_idx = -1
+      for f = 0, fx_count - 1 do
+        local _, fx_name = reaper.TrackFX_GetFXName(track, f)
+        if fx_name and fx_name:find(LIMITER_FX_NAME_PATTERN, 1, true) then
+          fx_idx = f
+          break
+        end
+      end
+      if fx_idx >= 0 then
+        local track_idx = i + 1  -- 1-based to match meter convention
+        local gr_db = reaper.TrackFX_GetParam(track, fx_idx, 4)  -- slider5
+        if dt_ms > 0 and gr_db < LIMITER_GR_THRESHOLD_DB then
+          limiter_active_ms[track_idx] = (limiter_active_ms[track_idx] or 0) + dt_ms
+        end
+        local total = limiter_active_ms[track_idx] or 0
+        lim_parts[#lim_parts + 1] = track_idx .. ":" .. total
+      end
+    end
+  end
+  reaper.SetExtState(LIMITER_SECTION, LIMITER_TOTALS_KEY, table.concat(lim_parts, ";"), false)
+
+  reaper.SetExtState(SECTION, KEY, table.concat(parts, ";"), false)
+
+  -- Dynamic script registration via EXTSTATE (no REAPER restart needed)
+```
+
+- [ ] **Step 3: Verify the additions did not break the existing structure**
+
+```bash
+grep -n "REAPERIEM_LIMITER_ACTIVITY\|limiter_active_ms\|main()\|reaper.atexit\|reaper.defer" scripts/reascripts/meter_bridge.lua | head -15
+# Expected: see LIMITER_SECTION constant near top, limiter_active_ms init, the
+# new for-loop block in main(), and the unchanged main() / atexit / defer lines.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/reascripts/meter_bridge.lua
+git commit -m "feat(reascript): meter_bridge accumulates limiter activity per track (#145)"
+```
+
+---
+
+## Task 5: Extend ws.rs — LimiterParams.active_seconds + ResetLimiterActivity ClientMsg
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-core/src/ws.rs`
+
+Two changes in one type module: extend the existing `ServerMsg::LimiterParams`
+variant with `#[serde(default)] active_seconds: f64`, and add a new
+`ClientMsg::ResetLimiterActivity { track_index: usize }` variant. Three new
+unit tests cover serde roundtrip and backwards compatibility.
+
+- [ ] **Step 1: Write the failing serde test for backwards compatibility (RED)**
+
+Add to the bottom of the existing `mod tests { ... }` block (after the existing
+`test_server_msg_limiter_params_serialization` at line 835-849):
+
+```rust
+    #[test]
+    fn test_server_msg_limiter_params_active_seconds_default() {
+        // Older server may emit LimiterParams without active_seconds; new client
+        // must still deserialize it with active_seconds = 0.0.
+        let json = r#"{"event":"LimiterParams","data":{"track_index":23,"track_name":"PETRONELA inear","limit_db":-6.0,"limit_norm":0.0,"enabled":true}}"#;
+        let decoded: ServerMsg = serde_json::from_str(json).unwrap();
+        match decoded {
+            ServerMsg::LimiterParams { active_seconds, .. } => {
+                assert_eq!(active_seconds, 0.0);
+            }
+            _ => panic!("Expected LimiterParams variant"),
+        }
+    }
+
+    #[test]
+    fn test_server_msg_limiter_params_with_active_seconds() {
+        let msg = ServerMsg::LimiterParams {
+            track_index: 23,
+            track_name: "PETRONELA inear".to_string(),
+            limit_db: -6.0,
+            limit_norm: 0.0,
+            enabled: true,
+            active_seconds: 83.5,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"active_seconds\":83.5"));
+        let back: ServerMsg = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn test_client_msg_reset_limiter_activity_serialization() {
+        let msg = ClientMsg::ResetLimiterActivity { track_index: 23 };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"cmd\":\"ResetLimiterActivity\""));
+        assert!(json.contains("\"track_index\":23"));
+        let back: ClientMsg = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+    }
+```
+
+- [ ] **Step 2: Add the new field to LimiterParams variant**
+
+In the `ServerMsg` enum at line 181-189, modify:
+
+```
+old_string:    /// Limiter parameters for a track — single "limit" control (#72)
+    LimiterParams {
+        track_index: usize,
+        track_name: String,
+        /// Max output level in dB (-6 to 0)
+        limit_db: f32,
+        /// Normalized slider position (0-1)
+        limit_norm: f32,
+        enabled: bool,
+    },
+new_string:    /// Limiter parameters for a track — single "limit" control (#72)
+    LimiterParams {
+        track_index: usize,
+        track_name: String,
+        /// Max output level in dB (-6 to 0)
+        limit_db: f32,
+        /// Normalized slider position (0-1)
+        limit_norm: f32,
+        enabled: bool,
+        /// Cumulative seconds the limiter has been actively reducing gain
+        /// (GR < -1 dB) since the last reset or app restart (#145).
+        /// Default 0.0 for backwards compatibility with older servers.
+        #[serde(default)]
+        active_seconds: f64,
+    },
+```
+
+- [ ] **Step 3: Add the new ClientMsg variant**
+
+In the `ClientMsg` enum at line 100-101, modify (insert AFTER the existing
+`SetLimiterEnabled` variant, BEFORE the closing `}`):
+
+```
+old_string:    /// Enable/disable limiter (FX bypass toggle) (#72)
+    SetLimiterEnabled { track_index: usize, enabled: bool },
+}
+new_string:    /// Enable/disable limiter (FX bypass toggle) (#72)
+    SetLimiterEnabled { track_index: usize, enabled: bool },
+    /// Reset the activity counter for one limiter track (#145).
+    /// Server zeros AppState.limiter_activity[track] AND writes
+    /// EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"
+    /// so meter_bridge.lua zeros its local accumulator (otherwise the
+    /// next poller cycle would re-overwrite the server's zero).
+    ResetLimiterActivity { track_index: usize },
+}
+```
+
+- [ ] **Step 4: Update the existing `test_server_msg_limiter_params_serialization` test**
+
+The pre-existing test at line 835-849 constructs `ServerMsg::LimiterParams`
+without `active_seconds`. With the new required-but-defaulted field, you must
+either set it explicitly or rely on `#[serde(default)]`. Update the test to
+construct the value explicitly so the test exercises the new field:
+
+```
+old_string:    #[test]
+    fn test_server_msg_limiter_params_serialization() {
+        let msg = ServerMsg::LimiterParams {
+            track_index: 23,
+            track_name: "PETRONELA inear".to_string(),
+            limit_db: -6.0,
+            limit_norm: 0.0,
+            enabled: true,
+        };
+new_string:    #[test]
+    fn test_server_msg_limiter_params_serialization() {
+        let msg = ServerMsg::LimiterParams {
+            track_index: 23,
+            track_name: "PETRONELA inear".to_string(),
+            limit_db: -6.0,
+            limit_norm: 0.0,
+            enabled: true,
+            active_seconds: 0.0,
+        };
+```
+
+- [ ] **Step 5: Verify formatting + commit (no local cargo build/test — runs in CI)**
+
+```bash
+cargo fmt --all --check  # MUST pass; if it complains, run `cargo fmt --all` and re-stage
+git add iem-mixer/crates/iem-core/src/ws.rs
+git commit -m "feat(core): LimiterParams.active_seconds + ResetLimiterActivity (#145)"
+```
+
+---
+
+## Task 6: AppState — add limiter_activity HashMap
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/lib.rs:99-154` (struct definition)
+- Modify: `iem-mixer/crates/iem-server/src/lib.rs:207-249` (`AppState::new` initializer)
+
+The existing struct uses `tokio::sync::Mutex` for limiter locks (lines 151, 153)
+but `Arc<RwLock<...>>` for the bigger config / cache state. For a small map
+that we read in the WS recv path (sync) and write from the poller (async), an
+`Arc<tokio::sync::Mutex<HashMap<usize, u64>>>` matches the existing limiter
+mutex flavor and avoids pulling in `parking_lot`.
+
+- [ ] **Step 1: Add the new field to the struct**
+
+In `pub struct AppState { ... }` (line 99-154), add the field at the very end
+(after `limiter_read_lock`):
+
+```
+old_string:    /// Mutex to serialize limiter EXTSTATE reads (#72)
+    pub limiter_read_lock: Arc<tokio::sync::Mutex<()>>,
+}
+new_string:    /// Mutex to serialize limiter EXTSTATE reads (#72)
+    pub limiter_read_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Per-inear-track cumulative active milliseconds from the limiter
+    /// (#145). Populated by the background poller from EXTSTATE
+    /// REAPERIEM_LIMITER_ACTIVITY/totals; zeroed entry-by-entry via the
+    /// ClientMsg::ResetLimiterActivity handler.
+    pub limiter_activity: Arc<tokio::sync::Mutex<std::collections::HashMap<usize, u64>>>,
+}
+```
+
+- [ ] **Step 2: Initialize the field in AppState::new**
+
+In the struct literal returned from `AppState::new` (around line 240-248), add
+the new field initializer:
+
+```
+old_string:            limiter_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            limiter_read_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+}
+new_string:            limiter_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            limiter_read_lock: Arc::new(tokio::sync::Mutex::new(())),
+            limiter_activity: Arc::new(tokio::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify formatting + commit**
+
+```bash
+cargo fmt --all --check
+git add iem-mixer/crates/iem-server/src/lib.rs
+git commit -m "feat(server): AppState.limiter_activity HashMap (#145)"
+```
+
+---
+
+## Task 7: poller.rs — read REAPERIEM_LIMITER_ACTIVITY/totals each cycle + parser unit test
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/poller.rs`
+
+Add a tiny pure parser `parse_limiter_activity_totals(text: &str) -> HashMap<usize, u64>`
+near the existing `parse_meter_bridge` function (line 33). Then in the cycle
+body, after the existing meter bridge EXTSTATE read (~line 474), read the
+limiter activity totals key and replace the AppState HashMap contents.
+
+- [ ] **Step 1: Write the failing parser unit test (RED)**
+
+In the existing test module at the bottom of `poller.rs` (or create one if it
+doesn't exist — search for `#[cfg(test)]\nmod tests` first), add:
+
+```rust
+    #[test]
+    fn parse_limiter_activity_totals_parses_pairs() {
+        let text = "23:1230;24:0;25:8470";
+        let parsed = super::parse_limiter_activity_totals(text);
+        assert_eq!(parsed.get(&23), Some(&1230));
+        assert_eq!(parsed.get(&24), Some(&0));
+        assert_eq!(parsed.get(&25), Some(&8470));
+        assert_eq!(parsed.len(), 3);
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_empty_input() {
+        assert!(super::parse_limiter_activity_totals("").is_empty());
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_skips_malformed_entries() {
+        let text = "23:1230;garbage;24:not_a_number;25:9999";
+        let parsed = super::parse_limiter_activity_totals(text);
+        assert_eq!(parsed.get(&23), Some(&1230));
+        assert_eq!(parsed.get(&25), Some(&9999));
+        assert_eq!(parsed.len(), 2);
+    }
+```
+
+If `poller.rs` has no `#[cfg(test)] mod tests` block, add this at the very
+bottom of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn parse_limiter_activity_totals_parses_pairs() {
+        let text = "23:1230;24:0;25:8470";
+        let parsed = super::parse_limiter_activity_totals(text);
+        assert_eq!(parsed.get(&23), Some(&1230));
+        assert_eq!(parsed.get(&24), Some(&0));
+        assert_eq!(parsed.get(&25), Some(&8470));
+        assert_eq!(parsed.len(), 3);
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_empty_input() {
+        assert!(super::parse_limiter_activity_totals("").is_empty());
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_skips_malformed_entries() {
+        let text = "23:1230;garbage;24:not_a_number;25:9999";
+        let parsed = super::parse_limiter_activity_totals(text);
+        assert_eq!(parsed.get(&23), Some(&1230));
+        assert_eq!(parsed.get(&25), Some(&9999));
+        assert_eq!(parsed.len(), 2);
+    }
+}
+```
+
+- [ ] **Step 2: Add the parser implementation**
+
+Add immediately AFTER the existing `pub fn parse_meter_bridge(...)` (which
+ends around line 56):
+
+```rust
+/// Parse limiter activity EXTSTATE response into per-track active_ms map.
+/// Input format: "23:1230;24:0;25:8470" (track_idx_1based:active_ms_u64)
+/// Skips malformed entries silently.
+pub fn parse_limiter_activity_totals(text: &str) -> HashMap<usize, u64> {
+    let mut totals = HashMap::new();
+    for entry in text.split(';') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((idx_str, ms_str)) = entry.split_once(':')
+            && let Ok(track_idx) = idx_str.parse::<usize>()
+            && let Ok(ms) = ms_str.parse::<u64>()
+        {
+            totals.insert(track_idx, ms);
+        }
+    }
+    totals
+}
+```
+
+- [ ] **Step 3: Add the EXTSTATE read in the poller cycle**
+
+Find the existing block at lines 474-489 (the meter bridge EXTSTATE read inside
+`if connected { ... }`). Add a sibling read for limiter activity totals
+immediately AFTER that block, BEFORE the closing `}` of the `if connected`
+scope.
+
+The existing block ends with:
+
+```rust
+        let extstate_url = reaper_api::get_extstate(&reaper_url, "REAPERIEM_METERS", "peaks");
+        if let Ok(resp) = state.http_client.get(&extstate_url).send().await
+            && let Ok(text) = resp.text().await
+        {
+            // REAPER EXTSTATE response: "EXTSTATE\tSECTION\tKEY\tvalue"
+            if let Some(value) = text.split('\t').nth(3)
+                && !value.is_empty()
+            {
+                let bridge_meters = parse_meter_bridge(value);
+                if !bridge_meters.is_empty() {
+                    // Override TRACK field meters with true L/R data
+                    meters = bridge_meters;
+                }
+            }
+        }
+    }
+```
+
+Apply with `Edit`:
+
+```
+old_string:        let extstate_url = reaper_api::get_extstate(&reaper_url, "REAPERIEM_METERS", "peaks");
+        if let Ok(resp) = state.http_client.get(&extstate_url).send().await
+            && let Ok(text) = resp.text().await
+        {
+            // REAPER EXTSTATE response: "EXTSTATE\tSECTION\tKEY\tvalue"
+            if let Some(value) = text.split('\t').nth(3)
+                && !value.is_empty()
+            {
+                let bridge_meters = parse_meter_bridge(value);
+                if !bridge_meters.is_empty() {
+                    // Override TRACK field meters with true L/R data
+                    meters = bridge_meters;
+                }
+            }
+        }
+    }
+new_string:        let extstate_url = reaper_api::get_extstate(&reaper_url, "REAPERIEM_METERS", "peaks");
+        if let Ok(resp) = state.http_client.get(&extstate_url).send().await
+            && let Ok(text) = resp.text().await
+        {
+            // REAPER EXTSTATE response: "EXTSTATE\tSECTION\tKEY\tvalue"
+            if let Some(value) = text.split('\t').nth(3)
+                && !value.is_empty()
+            {
+                let bridge_meters = parse_meter_bridge(value);
+                if !bridge_meters.is_empty() {
+                    // Override TRACK field meters with true L/R data
+                    meters = bridge_meters;
+                }
+            }
+        }
+
+        // Limiter activity totals (#145) — meter_bridge.lua writes per-track
+        // cumulative active milliseconds where the limiter is reducing gain.
+        let lim_url = reaper_api::get_extstate(
+            &reaper_url,
+            "REAPERIEM_LIMITER_ACTIVITY",
+            "totals",
+        );
+        if let Ok(resp) = state.http_client.get(&lim_url).send().await
+            && let Ok(text) = resp.text().await
+            && let Some(value) = text.split('\t').nth(3)
+        {
+            let totals = parse_limiter_activity_totals(value);
+            let mut guard = state.limiter_activity.lock().await;
+            *guard = totals;
+        }
+    }
+```
+
+- [ ] **Step 4: Verify formatting + commit**
+
+```bash
+cargo fmt --all --check
+git add iem-mixer/crates/iem-server/src/poller.rs
+git commit -m "feat(server): poller reads limiter activity totals from EXTSTATE (#145)"
+```
+
+---
+
+## Task 8: proxy.rs — handle ResetLimiterActivity command + enrich GetLimiterParams reply
+
+**Files:**
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs:1230-1311` (WS recv loop limiter handlers)
+- Modify: `iem-mixer/crates/iem-server/src/proxy.rs:2505-2555` (`handle_get_limiter_params` reply)
+
+Two distinct integrations:
+
+(a) Add `ClientMsg::ResetLimiterActivity` handler in the WS recv loop next to
+the existing `GetLimiterParams` / `SetLimiterParam` / `SetLimiterEnabled`
+handlers. Reuse the existing `owns_limiter_track` closure for the
+member-vs-engineer authorization check. On allow, zero the AppState HashMap
+entry AND write `EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"`
+so meter_bridge.lua zeros its local accumulator.
+
+(b) In `handle_get_limiter_params`, after building the `LimiterParams` reply
+via `parse_limiter_params_response`, replace the constructed value with one
+that includes `active_seconds` looked up from `state.limiter_activity[track_index]`.
+
+- [ ] **Step 1: Write the failing serde test for the new ClientMsg already done in Task 5 — confirm it still passes**
+
+The serde roundtrip lives in `iem-core/src/ws.rs`. No new test fixture is needed
+here. Move on.
+
+- [ ] **Step 2: Add the `ResetLimiterActivity` handler in the WS recv loop**
+
+Add immediately AFTER the existing `if let iem_core::ClientMsg::SetLimiterEnabled { ... }` block (which ends at line 1310 with `continue;` and `}`):
+
+```
+old_string:                            if let iem_core::ClientMsg::SetLimiterEnabled {
+                                track_index,
+                                enabled,
+                            } = cmd
+                            {
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    tokio::spawn(async move {
+                                        handle_set_limiter_param(
+                                            &state_clone,
+                                            track_index,
+                                            "enabled",
+                                            if enabled { 1.0 } else { 0.0 },
+                                        )
+                                        .await;
+                                    });
+                                }
+                                continue;
+                            }
+new_string:                            if let iem_core::ClientMsg::SetLimiterEnabled {
+                                track_index,
+                                enabled,
+                            } = cmd
+                            {
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    tokio::spawn(async move {
+                                        handle_set_limiter_param(
+                                            &state_clone,
+                                            track_index,
+                                            "enabled",
+                                            if enabled { 1.0 } else { 0.0 },
+                                        )
+                                        .await;
+                                    });
+                                }
+                                continue;
+                            }
+                            if let iem_core::ClientMsg::ResetLimiterActivity { track_index } = cmd
+                            {
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    tokio::spawn(async move {
+                                        handle_reset_limiter_activity(&state_clone, track_index)
+                                            .await;
+                                    });
+                                }
+                                continue;
+                            }
+```
+
+- [ ] **Step 3: Add the `handle_reset_limiter_activity` function**
+
+Add immediately AFTER the existing `handle_set_limiter_param` function (which
+ends around line 2648 with the closing `}`):
+
+```rust
+/// Reset the activity counter for one limiter track (#145).
+/// Zeros AppState.limiter_activity[track] AND writes
+/// EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"
+/// so meter_bridge.lua zeros its local accumulator on its next tick
+/// (otherwise the next poller cycle would re-overwrite the server zero).
+pub async fn handle_reset_limiter_activity(state: &AppState, track_index: usize) {
+    {
+        let mut guard = state.limiter_activity.lock().await;
+        guard.insert(track_index, 0);
+    }
+
+    let config = state.config.read().await;
+    let reaper_url = config.reaper_url.clone();
+    drop(config);
+
+    let set_url = reaper_api::set_extstate(
+        &reaper_url,
+        "REAPERIEM_LIMITER_ACTIVITY",
+        "reset",
+        &track_index.to_string(),
+    );
+    if state.http_client.get(&set_url).send().await.is_err() {
+        tracing::error!(
+            track_index,
+            "Limiter activity reset: failed to write reset EXTSTATE"
+        );
+    }
+}
+```
+
+Apply with `Edit` — paste the function immediately AFTER the closing `}` of
+`handle_set_limiter_param` and BEFORE the `/// REAPER HTTP API URL builder`
+doc comment that introduces `pub(crate) mod reaper_api`:
+
+```
+old_string:/// REAPER HTTP API URL builder
+/// CRITICAL: All REAPER API commands MUST use the `/_/` prefix!
+new_string:/// Reset the activity counter for one limiter track (#145).
+/// Zeros AppState.limiter_activity[track] AND writes
+/// EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"
+/// so meter_bridge.lua zeros its local accumulator on its next tick
+/// (otherwise the next poller cycle would re-overwrite the server zero).
+pub async fn handle_reset_limiter_activity(state: &AppState, track_index: usize) {
+    {
+        let mut guard = state.limiter_activity.lock().await;
+        guard.insert(track_index, 0);
+    }
+
+    let config = state.config.read().await;
+    let reaper_url = config.reaper_url.clone();
+    drop(config);
+
+    let set_url = reaper_api::set_extstate(
+        &reaper_url,
+        "REAPERIEM_LIMITER_ACTIVITY",
+        "reset",
+        &track_index.to_string(),
+    );
+    if state.http_client.get(&set_url).send().await.is_err() {
+        tracing::error!(
+            track_index,
+            "Limiter activity reset: failed to write reset EXTSTATE"
+        );
+    }
+}
+
+/// REAPER HTTP API URL builder
+/// CRITICAL: All REAPER API commands MUST use the `/_/` prefix!
+```
+
+- [ ] **Step 4: Enrich `handle_get_limiter_params` with active_seconds**
+
+In `handle_get_limiter_params` (line 2505), replace the bare
+`parse_limiter_params_response(track_index, value)` call at the end with a
+version that injects `active_seconds`. The parser today returns
+`Some(ServerMsg::LimiterParams { ..., enabled, active_seconds: 0.0 })` — we
+overwrite `active_seconds` from the AppState HashMap before returning.
+
+```
+old_string:    parse_limiter_params_response(track_index, value)
+}
+
+/// Parse limiter EXTSTATE response into ServerMsg
+new_string:    let mut reply = parse_limiter_params_response(track_index, value)?;
+    if let iem_core::ServerMsg::LimiterParams {
+        ref mut active_seconds,
+        ..
+    } = reply
+    {
+        let guard = state.limiter_activity.lock().await;
+        let ms = guard.get(&track_index).copied().unwrap_or(0);
+        *active_seconds = (ms as f64) / 1000.0;
+    }
+    Some(reply)
+}
+
+/// Parse limiter EXTSTATE response into ServerMsg
+```
+
+- [ ] **Step 5: Update the existing parser to default `active_seconds: 0.0`**
+
+The function `parse_limiter_params_response` at line 2558 builds a `LimiterParams`
+in two places (NO_LIMITER branch around line 2562, and the OK branch around line
+2596). Both must include `active_seconds: 0.0` after the new field is added to
+the variant.
+
+```
+old_string:    if value.starts_with("NO_LIMITER:") {
+        let track_name = value.strip_prefix("NO_LIMITER:").unwrap_or("").to_string();
+        return Some(iem_core::ServerMsg::LimiterParams {
+            track_index,
+            track_name,
+            limit_db: 0.0,
+            limit_norm: 0.0,
+            enabled: false,
+        });
+    }
+new_string:    if value.starts_with("NO_LIMITER:") {
+        let track_name = value.strip_prefix("NO_LIMITER:").unwrap_or("").to_string();
+        return Some(iem_core::ServerMsg::LimiterParams {
+            track_index,
+            track_name,
+            limit_db: 0.0,
+            limit_norm: 0.0,
+            enabled: false,
+            active_seconds: 0.0,
+        });
+    }
+```
+
+```
+old_string:    Some(iem_core::ServerMsg::LimiterParams {
+        track_index,
+        track_name,
+        limit_db: get_field("limit="),
+        limit_norm: get_field("limit_n="),
+        enabled: get_field("enabled=") >= 0.5,
+    })
+}
+new_string:    Some(iem_core::ServerMsg::LimiterParams {
+        track_index,
+        track_name,
+        limit_db: get_field("limit="),
+        limit_norm: get_field("limit_n="),
+        enabled: get_field("enabled=") >= 0.5,
+        active_seconds: 0.0,
+    })
+}
+```
+
+- [ ] **Step 6: Verify formatting + commit**
+
+```bash
+cargo fmt --all --check
+git add iem-mixer/crates/iem-server/src/proxy.rs
+git commit -m "feat(server): ResetLimiterActivity handler + enrich LimiterParams (#145)"
+```
+
+---
+
+## Task 9: LimiterModal — add active_seconds + Reset button
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/src/components/limiter_modal.rs`
+
+Add two new component props (`active_seconds: ReadSignal<f64>` and `on_reset:
+Callback<()>`) plus a small `format_active(secs: f64) -> String` helper. Render
+a new row between the existing toggle row and the closing `</div>`.
+
+- [ ] **Step 1: Add the helper function**
+
+Insert immediately AFTER the existing `norm_to_db` helper (around line 19),
+BEFORE the `LimiterModal` component definition:
+
+```rust
+/// Format active seconds for display in the modal: "never" when zero,
+/// otherwise "M:SS" with seconds floored. (#145)
+fn format_active(secs: f64) -> String {
+    if secs <= 0.0 {
+        return "never".to_string();
+    }
+    let total_secs = secs.floor() as u64;
+    let m = total_secs / 60;
+    let s = total_secs % 60;
+    format!("{}:{:02}", m, s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_active;
+
+    #[test]
+    fn format_active_zero_is_never() {
+        assert_eq!(format_active(0.0), "never");
+    }
+
+    #[test]
+    fn format_active_negative_is_never() {
+        assert_eq!(format_active(-1.0), "never");
+    }
+
+    #[test]
+    fn format_active_under_one_minute() {
+        assert_eq!(format_active(0.5), "0:00");
+        assert_eq!(format_active(1.0), "0:01");
+        assert_eq!(format_active(59.99), "0:59");
+    }
+
+    #[test]
+    fn format_active_minutes() {
+        assert_eq!(format_active(60.0), "1:00");
+        assert_eq!(format_active(83.5), "1:23");
+        assert_eq!(format_active(125.0), "2:05");
+        assert_eq!(format_active(3661.0), "61:01");
+    }
+}
+```
+
+Apply with `Edit`:
+
+```
+old_string:/// Convert norm (0-1) to dB (-6 to 0), handling negative zero
+fn norm_to_db(norm: f32) -> f32 {
+    let db = norm * 6.0 - 6.0;
+    if db == 0.0 { 0.0 } else { db } // eliminate -0.0
+}
+new_string:/// Convert norm (0-1) to dB (-6 to 0), handling negative zero
+fn norm_to_db(norm: f32) -> f32 {
+    let db = norm * 6.0 - 6.0;
+    if db == 0.0 { 0.0 } else { db } // eliminate -0.0
+}
+
+/// Format active seconds for display in the modal: "never" when zero,
+/// otherwise "M:SS" with seconds floored. (#145)
+fn format_active(secs: f64) -> String {
+    if secs <= 0.0 {
+        return "never".to_string();
+    }
+    let total_secs = secs.floor() as u64;
+    let m = total_secs / 60;
+    let s = total_secs % 60;
+    format!("{}:{:02}", m, s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_active;
+
+    #[test]
+    fn format_active_zero_is_never() {
+        assert_eq!(format_active(0.0), "never");
+    }
+
+    #[test]
+    fn format_active_negative_is_never() {
+        assert_eq!(format_active(-1.0), "never");
+    }
+
+    #[test]
+    fn format_active_under_one_minute() {
+        assert_eq!(format_active(0.5), "0:00");
+        assert_eq!(format_active(1.0), "0:01");
+        assert_eq!(format_active(59.99), "0:59");
+    }
+
+    #[test]
+    fn format_active_minutes() {
+        assert_eq!(format_active(60.0), "1:00");
+        assert_eq!(format_active(83.5), "1:23");
+        assert_eq!(format_active(125.0), "2:05");
+        assert_eq!(format_active(3661.0), "61:01");
+    }
+}
+```
+
+- [ ] **Step 2: Add the new props on the `LimiterModal` component signature**
+
+In the `#[component] pub fn LimiterModal(...)` signature (line 22-40), add two
+new parameters AFTER `loading: ReadSignal<bool>` and BEFORE `on_param_change`:
+
+```
+old_string:    /// Whether limiter FX is enabled (not bypassed)
+    enabled: ReadSignal<bool>,
+    /// Whether data is loading
+    loading: ReadSignal<bool>,
+    /// Callback when a parameter changes: (param_name, normalized_value)
+    on_param_change: Callback<(String, f32)>,
+new_string:    /// Whether limiter FX is enabled (not bypassed)
+    enabled: ReadSignal<bool>,
+    /// Whether data is loading
+    loading: ReadSignal<bool>,
+    /// Cumulative seconds the limiter has actively reduced gain (#145).
+    active_seconds: ReadSignal<f64>,
+    /// Callback when a parameter changes: (param_name, normalized_value)
+    on_param_change: Callback<(String, f32)>,
+    /// Callback when the user clicks the Reset activity button (#145).
+    on_reset: Callback<()>,
+```
+
+- [ ] **Step 3: Render the new row inside the loaded view**
+
+Inside the `else` branch (the loaded params view, line 56-95), add a new row
+AFTER the `<div class="limiter-toggle-row">...</div>` block and BEFORE the
+closing `</div>` of `<div class="limiter-params">`:
+
+```
+old_string:                                <div class="limiter-toggle-row">
+                                    <span>"Limiter"</span>
+                                    <button
+                                        class=move || {
+                                            if enabled.get() {
+                                                "limiter-toggle-btn on"
+                                            } else {
+                                                "limiter-toggle-btn off"
+                                            }
+                                        }
+                                        on:click=move |_| {
+                                            on_enabled_change.run(!enabled.get_untracked())
+                                        }
+                                    >
+                                        {move || if enabled.get() { "ON" } else { "OFF" }}
+                                    </button>
+                                    {move || {
+                                        if !enabled.get() {
+                                            view! {
+                                                <span class="limiter-warning">
+                                                    "HEARING PROTECTION OFF"
+                                                </span>
+                                            }
+                                                .into_any()
+                                        } else {
+                                            view! {}.into_any()
+                                        }
+                                    }}
+                                </div>
+                            </div>
+new_string:                                <div class="limiter-toggle-row">
+                                    <span>"Limiter"</span>
+                                    <button
+                                        class=move || {
+                                            if enabled.get() {
+                                                "limiter-toggle-btn on"
+                                            } else {
+                                                "limiter-toggle-btn off"
+                                            }
+                                        }
+                                        on:click=move |_| {
+                                            on_enabled_change.run(!enabled.get_untracked())
+                                        }
+                                    >
+                                        {move || if enabled.get() { "ON" } else { "OFF" }}
+                                    </button>
+                                    {move || {
+                                        if !enabled.get() {
+                                            view! {
+                                                <span class="limiter-warning">
+                                                    "HEARING PROTECTION OFF"
+                                                </span>
+                                            }
+                                                .into_any()
+                                        } else {
+                                            view! {}.into_any()
+                                        }
+                                    }}
+                                </div>
+                                <div class="limiter-activity-row">
+                                    <span class="limiter-activity-label">
+                                        "Active: "
+                                        {move || format_active(active_seconds.get())}
+                                    </span>
+                                    <button
+                                        class="limiter-reset-btn"
+                                        on:click=move |_| on_reset.run(())
+                                    >
+                                        "Reset"
+                                    </button>
+                                </div>
+                            </div>
+```
+
+- [ ] **Step 4: Verify formatting + commit**
+
+```bash
+cargo fmt --all --check
+git add iem-mixer/iem-ui/src/components/limiter_modal.rs
+git commit -m "feat(ui): LimiterModal active counter + Reset button (#145)"
+```
+
+---
+
+## Task 10: mixer.rs — wire active_seconds signal + on_reset callback end-to-end
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/src/pages/mixer.rs`
+
+Add the new signal pair, populate it from the existing `LimiterParams` handler,
+extend `connect_websocket`'s parameter list, and pass the signal + callback to
+the rendered `LimiterModal`. Two callsites of `connect_websocket` (initial
+connect + reconnect closure) must be updated symmetrically.
+
+- [ ] **Step 1: Add the signal pair declaration**
+
+Around line 747, AFTER the existing `let (limiter_loading, set_limiter_loading) = signal(false);`
+line, add:
+
+```
+old_string:    let (limiter_loading, set_limiter_loading) = signal(false);
+new_string:    let (limiter_loading, set_limiter_loading) = signal(false);
+    // Limiter activity counter (#145) — cumulative seconds since last reset.
+    let (limiter_active_seconds, set_limiter_active_seconds) = signal(0.0_f64);
+```
+
+- [ ] **Step 2: Extend `connect_websocket`'s parameter list**
+
+The function signature is around line 70-115 (search for `fn connect_websocket(`).
+Add a new parameter `set_limiter_active_seconds: WriteSignal<f64>` immediately
+after the existing `set_limiter_loading: WriteSignal<bool>,`:
+
+```
+old_string:    // Limiter signals (#72) — single "max level" control
+    set_limiter_limit_db: WriteSignal<f32>,
+    set_limiter_limit_norm: WriteSignal<f32>,
+    set_limiter_enabled: WriteSignal<bool>,
+    set_limiter_loading: WriteSignal<bool>,
+new_string:    // Limiter signals (#72) — single "max level" control
+    set_limiter_limit_db: WriteSignal<f32>,
+    set_limiter_limit_norm: WriteSignal<f32>,
+    set_limiter_enabled: WriteSignal<bool>,
+    set_limiter_loading: WriteSignal<bool>,
+    /// Limiter activity counter (#145)
+    set_limiter_active_seconds: WriteSignal<f64>,
+```
+
+- [ ] **Step 3: Populate the signal in the `LimiterParams` match arm**
+
+The handler is around line 391-402. Update the destructuring AND the body:
+
+```
+old_string:                    iem_core::ServerMsg::LimiterParams {
+                        track_index: _,
+                        track_name: _,
+                        limit_db,
+                        limit_norm,
+                        enabled,
+                    } => {
+                        let _ = set_limiter_limit_db.try_set(limit_db);
+                        let _ = set_limiter_limit_norm.try_set(limit_norm);
+                        let _ = set_limiter_enabled.try_set(enabled);
+                        let _ = set_limiter_loading.try_set(false);
+                    }
+new_string:                    iem_core::ServerMsg::LimiterParams {
+                        track_index: _,
+                        track_name: _,
+                        limit_db,
+                        limit_norm,
+                        enabled,
+                        active_seconds,
+                    } => {
+                        let _ = set_limiter_limit_db.try_set(limit_db);
+                        let _ = set_limiter_limit_norm.try_set(limit_norm);
+                        let _ = set_limiter_enabled.try_set(enabled);
+                        let _ = set_limiter_active_seconds.try_set(active_seconds);
+                        let _ = set_limiter_loading.try_set(false);
+                    }
+```
+
+- [ ] **Step 4: Pass the new signal at BOTH connect_websocket call sites**
+
+The first call site is around line 822-863 (initial connect inside `Effect::new`):
+
+```
+old_string:            set_limiter_limit_db,
+            set_limiter_limit_norm,
+            set_limiter_enabled,
+            set_limiter_loading,
+            set_alert_data,
+            alert_data,
+            set_alert_active,
+            set_talk_state,
+            set_engineer_talking,
+            page_visible_effect.clone(),
+        );
+    });
+new_string:            set_limiter_limit_db,
+            set_limiter_limit_norm,
+            set_limiter_enabled,
+            set_limiter_loading,
+            set_limiter_active_seconds,
+            set_alert_data,
+            alert_data,
+            set_alert_active,
+            set_talk_state,
+            set_engineer_talking,
+            page_visible_effect.clone(),
+        );
+    });
+```
+
+The second call site is around line 917-958 (reconnect closure). Apply the same
+single-line insertion:
+
+```
+old_string:                set_limiter_limit_db,
+                set_limiter_limit_norm,
+                set_limiter_enabled,
+                set_limiter_loading,
+                set_alert_data,
+                alert_data,
+                set_alert_active,
+                set_talk_state,
+                set_engineer_talking,
+                page_visible.clone(),
+            );
+        }
+    }) as Box<dyn FnMut()>);
+new_string:                set_limiter_limit_db,
+                set_limiter_limit_norm,
+                set_limiter_enabled,
+                set_limiter_loading,
+                set_limiter_active_seconds,
+                set_alert_data,
+                alert_data,
+                set_alert_active,
+                set_talk_state,
+                set_engineer_talking,
+                page_visible.clone(),
+            );
+        }
+    }) as Box<dyn FnMut()>);
+```
+
+- [ ] **Step 5: Pass active_seconds + on_reset to the rendered LimiterModal**
+
+In the `<Show when=move || limiter_open.get().is_some() ...>` block (around
+line 1572-1616), add the two new attributes. The existing block already binds
+`ti` from `limiter_open.get_untracked()` inside callbacks — reuse that pattern:
+
+```
+old_string:                        <LimiterModal
+                            track_name=track_name
+                            limit_db=limiter_limit_db
+                            limit_norm=limiter_limit_norm
+                            enabled=limiter_enabled
+                            loading=limiter_loading
+                            on_param_change=Callback::new(move |(param, value): (String, f32)| {
+new_string:                        <LimiterModal
+                            track_name=track_name
+                            limit_db=limiter_limit_db
+                            limit_norm=limiter_limit_norm
+                            enabled=limiter_enabled
+                            loading=limiter_loading
+                            active_seconds=limiter_active_seconds
+                            on_reset=Callback::new(move |_: ()| {
+                                if let Some((ti, _)) = limiter_open.get_untracked() {
+                                    ws_send(ws_for_lim, &iem_core::ClientMsg::ResetLimiterActivity {
+                                        track_index: ti,
+                                    });
+                                    // Optimistic local update so the user sees "never" immediately.
+                                    let _ = set_limiter_active_seconds.try_set(0.0);
+                                }
+                            })
+                            on_param_change=Callback::new(move |(param, value): (String, f32)| {
+```
+
+- [ ] **Step 6: Verify formatting + commit**
+
+```bash
+cargo fmt --all --check
+git add iem-mixer/iem-ui/src/pages/mixer.rs
+git commit -m "feat(ui): wire LimiterModal active_seconds + reset to WS (#145)"
+```
+
+---
+
+## Task 11: style.css — minor styling for the new row
+
+**Files:**
+- Modify: `iem-mixer/iem-ui/style.css`
+
+Add CSS rules for `.limiter-activity-row`, `.limiter-activity-label`, and
+`.limiter-reset-btn` matching the existing `.limiter-toggle-row` family.
+
+- [ ] **Step 1: Find the existing limiter modal CSS block**
+
+```bash
+grep -n "limiter-toggle-row\|limiter-toggle-btn\|limiter-warning" iem-mixer/iem-ui/style.css | head -10
+# Note the line range — the new rules go immediately after that block.
+```
+
+- [ ] **Step 2: Append new rules to style.css**
+
+Add the following at the end of the limiter section (immediately after the
+last `.limiter-warning {...}` block, or if you can't easily locate it, at the
+very end of the file):
+
+```css
+.limiter-activity-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.limiter-activity-label {
+  color: #ddd;
+}
+
+.limiter-reset-btn {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.limiter-reset-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.limiter-reset-btn:active {
+  background: rgba(255, 255, 255, 0.25);
+}
+```
+
+Use the `Edit` tool to insert at the appropriate location, or `Write` if
+appending to a long file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add iem-mixer/iem-ui/style.css
+git commit -m "style: limiter activity row + reset button (#145)"
+```
+
+---
+
+## Task 12: Live E2E — limiter-activity.spec.ts
+
+**Files:**
+- Create: `iem-mixer/e2e/tests/live/limiter-activity.spec.ts`
+
+End-to-end test that drives a hot signal into a member's mix via the existing
+`tone_generator` ReaScript, verifies the `Active:` line in their LimiterModal
+shows ≥ 5 s of accumulated activity, clicks Reset, and verifies the counter
+goes back to "never". This is the regression test for the entire feature.
+
+- [ ] **Step 1: Confirm the existing tone-generator pattern**
+
+```bash
+grep -n "tone_generator\|TONE_GEN\|_RS_REAPERIEM_TONE_GEN" iem-mixer/e2e/tests/live/*.spec.ts | head -10
+# Note which existing live spec uses tone_generator and how it triggers/stops it.
+# audio-pipeline.spec.ts is the most likely reference; copy that pattern.
+```
+
+- [ ] **Step 2: Create the spec file**
+
+Create `iem-mixer/e2e/tests/live/limiter-activity.spec.ts` with:
+
+```typescript
+/**
+ * Limiter Activity Counter — Issue #145
+ *
+ * Verifies that the per-track Active counter inside the LimiterModal
+ * accumulates time when the safety limiter is reducing gain, and that
+ * the Reset button zeros the counter (both server- and ReaScript-side).
+ *
+ * Requires REAPER on iem.lan with the modified MGA_JSLimiterST exposing
+ * slider5 (deployed by CI).  Uses the tone_generator ReaScript to drive
+ * a hot signal into the engineer's mix bus, which then exceeds the
+ * limiter ceiling (-6 dBFS by default) on the engineer's inear track.
+ */
+
+import { test, expect, Page } from "@playwright/test";
+
+const REAPER_URL = "http://iem.lan:8080";
+const TONE_GEN_ACTION = "_RS_REAPERIEM_TONE_GEN";
+
+async function loginAsEngineer(page: Page) {
+  const response = await page.request.post("/api/auth", {
+    data: { member: "engineer", pin: "1177" },
+  });
+  expect(response.status()).toBe(200);
+  const data = await response.json();
+  await page.evaluate(
+    ({ token, member, engineer }) => {
+      localStorage.setItem(
+        "iem_token",
+        JSON.stringify({ token, member, engineer }),
+      );
+    },
+    { token: data.token, member: data.member, engineer: data.engineer },
+  );
+}
+
+async function triggerToneGenerator(page: Page) {
+  // Toggles the test tone on the engineer track. First call = on, second = off.
+  await page.request.get(`${REAPER_URL}/_/${TONE_GEN_ACTION}`).catch(() => {});
+}
+
+async function readActiveText(page: Page): Promise<string> {
+  const label = page.locator(".limiter-activity-label");
+  await expect(label).toBeVisible({ timeout: 5000 });
+  return (await label.innerText()).trim();
+}
+
+function parseActiveSeconds(text: string): number {
+  // Format: "Active: never" or "Active: M:SS"
+  const stripped = text.replace(/^Active:\s*/, "").trim();
+  if (stripped === "never") return 0;
+  const match = stripped.match(/^(\d+):(\d{2})$/);
+  if (!match) {
+    throw new Error(`Unparseable active text: '${text}'`);
+  }
+  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+}
+
+test.describe("Limiter Activity Counter — Issue #145", () => {
+  const consoleMessages: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    consoleMessages.length = 0;
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        if (msg.text().includes("subscribe await failed")) return;
+        if (msg.text().includes("Push API in incognito")) return;
+        if (msg.text().includes("vapid-key fetch error")) return;
+        if (msg.text().includes("navigator.vibrate")) return;
+        if (msg.text().includes("closure invoked recursively")) return;
+        if (msg.text().includes("[vite]")) return;
+        if (msg.text().includes("favicon")) return;
+        if (msg.text().includes("integrity")) return;
+        if (msg.text().includes("WebSocket connection")) return;
+        consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+      }
+    });
+  });
+
+  test.afterEach(async () => {
+    expect(consoleMessages).toEqual([]);
+  });
+
+  test("counter accumulates while limiter is reducing gain, Reset zeros it", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    // Login + navigate to engineer's own mixer
+    await page.goto("/");
+    await loginAsEngineer(page);
+    await page.goto("/engineer");
+    await expect(page.locator(".mixer-header").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Make sure no test tone is leaking from a previous run; toggle off-then-on
+    // to ensure we start in a known state. The TONE_GEN action toggles, so we
+    // call once to whatever the current state was, wait, then trigger again to
+    // explicitly turn it ON.
+    await triggerToneGenerator(page);
+    await page.waitForTimeout(800);
+
+    // Find the LIM button on the engineer's own channel strip.
+    // ENGINEER inear is the engineer's own output bus; the modal we open is
+    // for that track.  We open the FIRST limiter button on the page, which
+    // for the engineer's mixer is their own.
+    const limitBtn = page.locator(".limiter-btn-small").first();
+    await expect(limitBtn).toBeVisible({ timeout: 10_000 });
+
+    // Reset first so we measure ONLY this test's accumulation.
+    await limitBtn.click();
+    await expect(page.locator(".limiter-modal")).toBeVisible({ timeout: 5000 });
+    const resetBtnPre = page.locator(".limiter-reset-btn");
+    await expect(resetBtnPre).toBeVisible();
+    await resetBtnPre.click();
+    // Close + reopen so we re-fetch active_seconds from the server.
+    await page.locator(".limiter-close-btn").click();
+    await expect(page.locator(".limiter-modal")).not.toBeVisible({
+      timeout: 2000,
+    });
+
+    // Now turn the tone ON (it was a no-op previously if it was already off).
+    await triggerToneGenerator(page);
+
+    // Hold the hot signal long enough for the limiter to engage and accumulate
+    // measurable active time.  meter_bridge polls per defer tick (~30 ms);
+    // 6 s of audible signal should produce well over 5 s of accumulated activity.
+    await page.waitForTimeout(6000);
+
+    // Open the modal again and read the counter
+    await limitBtn.click();
+    await expect(page.locator(".limiter-modal")).toBeVisible({ timeout: 5000 });
+    const activeText = await readActiveText(page);
+    const activeSecs = parseActiveSeconds(activeText);
+    expect(
+      activeSecs,
+      `Expected >= 5 s of limiter activity after a 6 s hot tone, got '${activeText}'`,
+    ).toBeGreaterThanOrEqual(5);
+
+    // Reset
+    const resetBtn = page.locator(".limiter-reset-btn");
+    await resetBtn.click();
+
+    // Stop the tone before the next assertion, otherwise meter_bridge will
+    // immediately accumulate again on the next tick and the counter will not
+    // remain at zero.
+    await triggerToneGenerator(page);
+    await page.waitForTimeout(800);
+
+    // Close + reopen modal to re-fetch active_seconds from the server.
+    await page.locator(".limiter-close-btn").click();
+    await expect(page.locator(".limiter-modal")).not.toBeVisible({
+      timeout: 2000,
+    });
+    await limitBtn.click();
+    await expect(page.locator(".limiter-modal")).toBeVisible({ timeout: 5000 });
+
+    const afterReset = await readActiveText(page);
+    expect(
+      parseActiveSeconds(afterReset),
+      `After Reset + tone-off + reopen, expected 'Active: never' or 'Active: 0:00'-'0:01', got '${afterReset}'`,
+    ).toBeLessThanOrEqual(1);
+
+    // Cleanly close before afterEach runs the console-error check.
+    await page.locator(".limiter-close-btn").click();
+  });
+});
+```
+
+- [ ] **Step 3: Verify the file was created**
+
+```bash
+ls -la iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+wc -l iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+# Should exist, ~150 lines.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+git commit -m "test(e2e): live limiter activity counter spec (#145)"
+```
+
+---
+
+## Task 13: README changelog
+
+**Files:**
+- Modify: `README.md`
+
+Per project CLAUDE.md, the changelog MUST be updated for every user-facing
+change. Add a v1.149.0 entry.
+
+- [ ] **Step 1: Locate the changelog block**
+
+```bash
+grep -n "^### v1.148\|^### v1.149\|^## Changelog" README.md | head -5
+# The new entry goes immediately after the "## Changelog" header line, BEFORE
+# the existing "### v1.148.0" entry.
+```
+
+- [ ] **Step 2: Insert the new entry**
+
+Replace the existing "### v1.148.0" header with the new entry placed above it:
+
+```
+old_string: ### v1.148.0
+new_string: ### v1.149.0 (2026-04-13)
+
+- **Feature**: Per-inear-track limiter activation counter (#145). Open the LIM dialog on any channel to see how long that inear's safety limiter has been actively reducing gain since the last reset, plus a Reset button to zero it. Visible to engineer (any track) and to band members on their own track.
+- **Note**: Existing limiter instances pick up the new GR readout on next REAPER FX reload (next REAPER restart or project reload).
+
+### v1.148.0
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: changelog entry for v1.149.0 limiter activity counter (#145)"
+```
+
+---
+
+## Task 14: Push, monitor CI, fix forward if needed
+
+- [ ] **Step 1: Run local format check (only allowed local check)**
+
+```bash
+cd iem-mixer && cargo fmt --all --check
+cd ..
+# Expected: clean exit. If it fails, run `cargo fmt --all`, re-stage, amend the
+# affected commit (NOT the version bump — make a fix-fmt commit if needed).
+```
+
+- [ ] **Step 2: Push**
+
+```bash
+git push origin dev
+```
+
+- [ ] **Step 3: Monitor CI to terminal state**
+
+Find the latest run:
+
+```bash
+gh run list --branch dev --limit 3
+```
+
+Watch it (background, single sleep — never use `gh run watch`):
+
+```bash
+RUN_ID=$(gh run list --branch dev --limit 1 --json databaseId --jq '.[0].databaseId')
+echo "Monitoring run $RUN_ID"
+# Use `gh run view $RUN_ID` to check status. ALL 10 jobs (lint, test,
+# build-wasm, e2e CI, build-tauri, test-integrity, deploy to iem.lan,
+# post-deploy E2E, etc.) MUST reach success.
+```
+
+- [ ] **Step 4: If any job fails, investigate and fix in ONE follow-up commit**
+
+```bash
+gh run view $RUN_ID --log-failed | head -200
+# Diagnose. Common failure modes for this PR:
+# - cargo fmt: re-format and commit
+# - Backwards-compat test in iem-core: confirm #[serde(default)] is on active_seconds
+# - Limiter activity E2E: tone_generator may need different action handling;
+#   check the action exists with `curl http://iem.lan:8080/_/_RS_REAPERIEM_TONE_GEN`
+# - Post-deploy: check `curl http://10.77.9.231/api/version` reports 1.149.0
+# - Limiter E2E times out reading slider5: existing limiter instances need
+#   REAPER FX reload — manually trigger setup_output_limiter on iem.lan to
+#   re-insert the FX and pick up slider5 (this is documented as the v1.149.0
+#   one-time degradation in the README changelog).
+# Fix all issues in one commit:
+git add <fixes>
+git commit -m "fix: <describe what was broken and how>"
+git push origin dev
+# Re-monitor.
+```
+
+---
+
+## Task 15: Open PR `dev → main`, verify mergeable, present URL, STOP
+
+- [ ] **Step 1: Confirm dev is fully ahead of main with green CI**
+
+```bash
+gh run list --branch dev --limit 3
+# Latest run on dev MUST be success.
+
+git fetch origin
+git log --oneline origin/main..origin/dev
+# Should list every commit added in this plan: version bump, JSFX fork,
+# CI deploy step, meter_bridge update, ws.rs, AppState, poller, proxy,
+# LimiterModal, mixer.rs, style.css, E2E spec, README changelog.
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base main --head dev --title "feat: limiter activation counter (#145)" --body "$(cat <<'EOF'
+## Summary
+- Adds a per-inear-track active-time counter and Reset button inside the existing LimiterModal.
+- Forks `MGA_JSLimiterST` to expose its existing internal `gr_meter` via a read-only slider5, which `meter_bridge.lua` polls every defer tick to accumulate active milliseconds whenever GR > 1 dB.
+- Server poller reads totals from a single EXTSTATE key into an in-memory `HashMap<usize, u64>` on `AppState`.
+- `ServerMsg::LimiterParams` extended with `active_seconds: f64` (default 0.0 for stale-PWA backwards compat). New `ClientMsg::ResetLimiterActivity { track_index }` zeros both server HashMap and ReaScript-side accumulator (via EXTSTATE round-trip).
+- Counter is visible to whoever can open the LimiterModal: member for own track, engineer for any track.
+- v1.149.0.
+
+## Test plan
+- [x] Unit: `iem-core::test_server_msg_limiter_params_active_seconds_default` — older server JSON without `active_seconds` deserializes with default 0.0.
+- [x] Unit: `iem-core::test_server_msg_limiter_params_with_active_seconds` — full roundtrip including the new field.
+- [x] Unit: `iem-core::test_client_msg_reset_limiter_activity_serialization` — ResetLimiterActivity serde roundtrip.
+- [x] Unit: `iem-server::poller::tests::parse_limiter_activity_totals_*` — three tests cover happy path, empty, and malformed input.
+- [x] Unit: `iem-ui::components::limiter_modal::tests::format_active_*` — four tests cover zero, negative, sub-minute, and minute-spanning formatting.
+- [x] Live E2E: `iem-mixer/e2e/tests/live/limiter-activity.spec.ts` — drives 6 s of hot tone via `_RS_REAPERIEM_TONE_GEN` against the real iem.lan REAPER, asserts Active counter ≥ 5 s, clicks Reset, asserts counter back to ≤ 1 s.
+- [x] CI: all 10 jobs green including Deploy to iem.lan and post-deploy E2E.
+- [x] Manual post-deploy: open the LIM modal on a member's mixer, observe the new "Active: ..." row.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2.5: Verify PR is mergeable (no conflicts, all checks green)**
+
+```bash
+PR_NUM=$(gh pr list --base main --head dev --json number --jq '.[0].number')
+gh api repos/zbynekdrlik/reaperiem/pulls/$PR_NUM \
+  --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state}'
+# Required for green-light: mergeable: true, mergeable_state: "clean"
+# If "behind", `git fetch origin && git push origin dev` after rebasing or merging main.
+# If "blocked" or "dirty", investigate the failing check or conflict.
+```
+
+- [ ] **Step 3: Present the URL and STOP**
+
+Output the PR URL to the user along with:
+- Latest run ID and its `success` status
+- Confirmation that `mergeable_state == "clean"`
+- A note that you are NOT merging — waiting for explicit user instruction.
+
+DO NOT call `gh pr merge`. The airuleset rule is absolute: explicit user
+"merge it" / "approved" / "go ahead" is required.
+
+---
+
+## Task dependencies
+
+```
+T1 (version bump) → MUST be first commit
+  ↓
+T2 (JSFX fork) ──┐
+T3 (CI deploy) ──┤  Independent — order T2 before T3 because T3 references the file path
+T4 (meter_bridge) ──┐
+T5 (ws.rs) ─────────┤
+T6 (AppState) ──────┤
+T7 (poller) — depends on T5 (uses HashMap field name) and T6 (state.limiter_activity)
+T8 (proxy) — depends on T5 (ResetLimiterActivity variant) and T6 (state.limiter_activity)
+T9 (LimiterModal) — depends on T5 (ServerMsg field for type checking)
+T10 (mixer.rs) — depends on T5, T9
+T11 (style.css) — independent
+T12 (E2E spec) — should be added before push so CI exercises it
+T13 (README) — independent
+  ↓
+T14 (push + monitor CI) — depends on all of the above
+  ↓
+T15 (PR + STOP) — depends on T14
+```
+
+Tasks T2 through T13 may run in any order once T1 is on disk; subagent driver
+should dispatch them sequentially to avoid Cargo.toml lockfile contention.
+
+---
+
+## Verification (after CI is green)
+
+1. **All CI jobs pass** including Deploy to iem.lan and post-deploy E2E
+2. **Post-deploy `/api/version`** returns `1.149.0`
+3. **Limiter modal** opens on a real member's mixer and shows the "Active:" row
+4. **PR `dev → main`** is mergeable and clean
+5. **Plan-fulfillment audit:** every `[ ]` checkbox in this plan is `[x]`

--- a/docs/superpowers/specs/2026-04-13-limiter-activation-counter-design.md
+++ b/docs/superpowers/specs/2026-04-13-limiter-activation-counter-design.md
@@ -1,0 +1,258 @@
+# Limiter Activation Counter — Design
+
+**Issue:** [#145](https://github.com/zbynekdrlik/reaperiem/issues/145) — "limiter activation log"
+
+**Goal:** Surface, inside the existing per-track Limiter modal, how long that track's output limiter has been actively reducing gain since the last reset. Both engineer and the band member themselves can see and reset their own counter.
+
+## Problem
+
+Engineer needs to know which band members' inears have had the safety limiter pushing the signal down, so they can either lower the engineer-side fader or coach the member to turn down. Today there is no observation of limiter gain reduction anywhere in the app — the limiter does its job silently.
+
+## Scope (explicit YAGNI list)
+
+In scope:
+- One extra line + one button inside the existing `LimiterModal`
+- Per-inear-track cumulative active milliseconds (reduction-time counter)
+- Per-track Reset button
+- Counter is visible to anyone who can open that track's modal: the member themselves (for their own track) and the engineer (for any track)
+
+Out of scope (do not build):
+- Peak GR readout
+- Live "currently active" indicator on channel strips or in the modal
+- Cross-member list / leaderboard / engineer-toolbar view
+- Per-event timeline or timestamps
+- Persistence across app restarts
+- Notifications, alerts, automatic actions
+
+## Architecture
+
+```
+REAPER (iem.lan)
+  └─ Each inear track: JS:loser/MGA_JSLimiterST (modified)
+       └─ slider5 = ext_gr_meter   (added; read-only readout, dB)
+       
+  └─ scripts/reascripts/meter_bridge.lua (existing defer loop, ~tick rate)
+       └─ For each inear track with the limiter:
+            read slider5 via TrackFX_GetParam
+            if value < -1.0 dB → activity_ms[track] += dt
+       └─ Write all totals to EXTSTATE: REAPERIEM_LIMITER_ACTIVITY/totals
+            Format: "23:1230;24:0;25:8470;..."   (track_index:active_ms)
+
+iem-mixer-app (iem.lan)
+  └─ poller.rs (existing 150 ms loop)
+       └─ Read REAPERIEM_LIMITER_ACTIVITY/totals each cycle
+       └─ Store in AppState.limiter_activity: HashMap<usize, u64>
+            (key = inear track index, value = active_ms cumulative)
+  └─ proxy.rs WebSocket handler (existing per-member WS)
+       └─ ServerMsg::LimiterParams extended: + active_seconds: f64
+            Sent in response to GetLimiterParams (when modal opens)
+       └─ ClientMsg::ResetLimiterActivity { track_index }
+            Server zeros the HashMap entry for that one track
+            ALSO writes EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"
+            so the ReaScript counter zeroes too (otherwise next poller cycle
+            would re-overwrite the server's zero)
+
+iem-ui (Leptos WASM)
+  └─ components/limiter_modal.rs
+       └─ Two new elements above the close button:
+            "Active: 1:23"  (or "Active: never" when zero)
+            [Reset] button → sends ClientMsg::ResetLimiterActivity
+       └─ active_seconds signal updated when LimiterParams arrives
+```
+
+## Detection mechanism
+
+`MGA_JSLimiterST` already computes a continuous gain-reduction value internally
+(`gr_meter`) and writes it to REAPER's `ext_gr_meter` extension for the FX UI's
+own meter display. We add one read-only slider that mirrors the same value, so
+ReaScript can poll it via `TrackFX_GetParam`:
+
+```jsfx
+// added to MGA_JSLimiterST after slider4
+slider5:0<-30,0,0.1>GR (dB read-only)
+
+// added to @block (after the existing ext_gr_meter assignment)
+slider5 = ext_gr_meter;
+sliderchange(slider5);
+```
+
+`sliderchange()` is the JSFX call that pushes the new slider value into REAPER's
+parameter automation system, making it readable from `TrackFX_GetParam(track, fx, 4)`
+(parameter index 4 = slider5, zero-based).
+
+**Activation threshold:** GR less than −1.0 dB counts as "limiter active". One dB
+is the conventional threshold for audible gain reduction; sub-1 dB reduction is
+transparent and shouldn't inflate the counter.
+
+**Tick rate:** meter_bridge already runs once per `defer()` cycle (~30 ms when REAPER
+audio is running). At each tick we add the elapsed wall time since the previous
+tick to `active_ms[track]` for every track currently above threshold. We measure
+elapsed time with `reaper.time_precise()` so a brief defer hiccup doesn't get
+counted as activation time.
+
+## Storage model
+
+In-memory only — `Arc<Mutex<HashMap<usize, u64>>>` on `AppState`, keyed by inear
+track index, value in milliseconds. Resets on:
+- App restart (HashMap is empty at startup)
+- Engineer or member explicitly clicks the per-track Reset button
+
+No persistence across app restarts. No auto-reset by time. The counter answers
+"since this app started, or since I last hit Reset, how long has the limiter
+been doing work on this track?"
+
+## Reset semantics
+
+`ClientMsg::ResetLimiterActivity { track_index }` does two things atomically:
+
+1. Server zeros `AppState.limiter_activity[track_index]`
+2. Server writes `EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"`
+
+meter_bridge.lua reads the reset key each tick. When set, it zeros the matching
+local accumulator and clears the EXTSTATE key. Without this round-trip, the next
+poller cycle would re-overwrite the server's zero with the ReaScript's still-large
+total.
+
+## Authorization
+
+The existing `LimiterModal` access rules already govern who can open the dialog:
+- Engineer can open any member's limiter modal (track ownership check `owns_limiter_track` in proxy.rs returns true for engineer)
+- A band member can open only their own track's modal (#156)
+
+The counter and Reset button inherit those rules unchanged. We do not add a
+separate engineer-only gate — if you're allowed to see the limiter modal for
+that track, you're allowed to see and reset its counter.
+
+## Wire format
+
+Extending the existing `ServerMsg::LimiterParams` variant in `iem-core/src/ws.rs`:
+
+```rust
+LimiterParams {
+    track_index: usize,
+    limit_db: f32,
+    limit_norm: f32,
+    enabled: bool,
+    active_seconds: f64,   // NEW — cumulative active seconds since reset
+}
+```
+
+New `ClientMsg` variant in `iem-core/src/ws.rs`:
+
+```rust
+ResetLimiterActivity { track_index: usize },
+```
+
+## UI
+
+Inside `LimiterModal` between the existing toggle row and the close area, one new
+row with two elements:
+
+```
+┌─────────────────────────────────────────┐
+│ PETRONELA — Limiter                  ✕  │
+├─────────────────────────────────────────┤
+│  ▮ MAX LEVEL  ──●─────────  -6.0 dB     │
+│                                         │
+│  Limiter   [ ON ]                       │
+│                                         │
+│  Active: 0:23           [ Reset ]       │  ← NEW row
+└─────────────────────────────────────────┘
+```
+
+Format rules:
+- 0 ms → "Active: never"
+- 1 ms to 59,999 ms → "Active: 0:0X" up to "Active: 0:59"
+- ≥ 60 s → "Active: M:SS" (no hours expected for a session-only counter)
+
+The counter does not auto-refresh while the modal is open in v1 (it's set once
+when LimiterParams arrives in response to GetLimiterParams on modal open). If
+the user wants a fresh value, they close and reopen the modal. (Live polling
+inside the modal is a v2 feature once we know whether the static reading is
+already useful.)
+
+## Testing
+
+Unit tests (Rust):
+1. `limiter_activity::accumulator_only_counts_below_threshold` — feed synthetic
+   GR samples (-0.5 dB, -1.5 dB, -3.0 dB, +0.0 dB), assert active_ms increments
+   only on the -1.5 and -3.0 samples.
+2. `proxy::reset_limiter_activity_authorization` — engineer can reset any track,
+   member can reset only their own (uses same `owns_limiter_track` helper).
+3. `proxy::reset_limiter_activity_zeros_state_and_writes_extstate` — verify both
+   the HashMap entry zero and the EXTSTATE write happen together.
+4. `serde::limiter_params_includes_active_seconds` — ServerMsg roundtrip
+   includes the new field.
+
+E2E live (deploy job, runs on iem.lan with real REAPER):
+1. `limiter-activity.spec.ts`:
+   - Login as engineer, navigate to a member's mixer
+   - Use `tone_generator` ReaScript to send a known signal hot enough to engage
+     the limiter (the existing tone generator already used by audio-pipeline tests)
+   - Hold for 5 seconds, stop tone
+   - Open that member's limiter modal
+   - Read the `Active:` line, parse `M:SS`, assert total seconds ≥ 5
+   - Click Reset
+   - Close modal, reopen
+   - Assert `Active: never`
+
+## Failure modes
+
+- **MGA_JSLimiterST modification breaks the limiter audio path:** Mitigated by
+  setup_output_limiter.lua's idempotent migration. We rebuild the JSFX file once
+  and ship via CI; existing inserted instances will pick up the new slider5 on
+  next REAPER reload of the FX. Audio path unchanged (we only added a read-only
+  slider — `gain` and `gainO` math is untouched).
+- **slider5 read returns zero (plugin not yet reloaded):** Counter stays at zero
+  for that track until reload. Acceptable degradation. We document the one-time
+  reload requirement in the v1.149.0 changelog.
+- **REAPER restart loses HashMap:** Intentional — counter is session-only.
+- **Server restart while ReaScript counter is non-zero:** Next poller cycle reads
+  REAPER's still-non-zero EXTSTATE total and seeds the server HashMap with it.
+  This is the right behavior (the counter is tracking what REAPER actually did,
+  not what the server happened to remember).
+- **`active_ms` overflow:** u64 ms is safe for ~580 million years. Not a
+  concern.
+
+## Versioning
+
+- Plugin file change → ships in v1.149.0
+- New `ServerMsg.active_seconds` field is additive (older WASM clients ignore it)
+- New `ClientMsg::ResetLimiterActivity` variant is additive (older servers
+  reject unknown variants — but the server ships first, so this is always safe
+  in our deploy order: server before frontend, both bundled in the same Tauri
+  installer)
+
+## File touch list
+
+- `scripts/reascripts/setup_output_limiter.lua` — bump comment header version
+- New: `scripts/reascripts/jsfx/MGA_JSLimiterST` — local fork with slider5 added
+  (deployed to `%APPDATA%\REAPER\Effects\loser\` by deploy step, replacing the
+  upstream copy)
+- `scripts/reascripts/meter_bridge.lua` — add limiter activity polling block,
+  EXTSTATE write, reset-key handling
+- `iem-mixer/crates/iem-core/src/ws.rs` — extend LimiterParams, add
+  ResetLimiterActivity ClientMsg
+- `iem-mixer/crates/iem-server/src/lib.rs` — add `limiter_activity` field on AppState
+- `iem-mixer/crates/iem-server/src/poller.rs` — read EXTSTATE, populate HashMap
+- `iem-mixer/crates/iem-server/src/proxy.rs` — handle ResetLimiterActivity command;
+  include active_seconds when responding to GetLimiterParams
+- `iem-mixer/iem-ui/src/components/limiter_modal.rs` — add Active row + Reset
+  button + new prop `active_seconds: ReadSignal<f64>` + reset callback
+- `iem-mixer/iem-ui/src/pages/mixer.rs` — wire active_seconds signal end-to-end
+- `iem-mixer/iem-ui/style.css` — minor styling for new row
+- New: `iem-mixer/e2e/tests/live/limiter-activity.spec.ts` — full E2E
+- `README.md` — v1.149.0 changelog entry
+- 5× `Cargo.toml` + `tauri.conf.json` — version bump 1.148.0 → 1.149.0
+
+## Open questions
+
+None at this point — three confirmations were collected during brainstorming:
+- Scope: cumulative totals only, no live indicator, no peak GR
+- Placement: inside existing LimiterModal (not toolbar)
+- Visibility: members and engineer alike (per existing modal access rules)
+
+And three defaults were taken, documented for spec-review override:
+- Activation threshold: GR > 1 dB
+- Reset model: per-track Reset button + auto-reset on app restart
+- Modal value: snapshot at open, no live polling inside modal (v2 if needed)

--- a/docs/superpowers/specs/2026-04-13-limiter-activation-counter-design.md
+++ b/docs/superpowers/specs/2026-04-13-limiter-activation-counter-design.md
@@ -55,7 +55,8 @@ iem-mixer-app (iem.lan)
 iem-ui (Leptos WASM)
   └─ components/limiter_modal.rs
        └─ Two new elements above the close button:
-            "Active: 1:23"  (or "Active: never" when zero)
+            "21.3 sec limited"  (or "not limited yet" when zero,
+                                    or "1 min 23 sec limited" at ≥60 s)
             [Reset] button → sends ClientMsg::ResetLimiterActivity
        └─ active_seconds signal updated when LimiterParams arrives
 ```
@@ -156,14 +157,18 @@ row with two elements:
 │                                         │
 │  Limiter   [ ON ]                       │
 │                                         │
-│  Active: 0:23           [ Reset ]       │  ← NEW row
+│  23.4 sec limited      [ Reset ]        │  ← NEW row
 └─────────────────────────────────────────┘
 ```
 
 Format rules:
-- 0 ms → "Active: never"
-- 1 ms to 59,999 ms → "Active: 0:0X" up to "Active: 0:59"
-- ≥ 60 s → "Active: M:SS" (no hours expected for a session-only counter)
+- 0 s → "not limited yet"
+- < 60 s → "X.X sec limited" (one decimal for resolution at short durations)
+- ≥ 60 s → "M min S sec limited" (no decimal; no hours expected in a session)
+
+The phrasing deliberately avoids an opaque "Active: M:SS" display — a user
+opening the modal for the first time must understand the number without
+external context.
 
 The counter does not auto-refresh while the modal is open in v1 (it's set once
 when LimiterParams arrives in response to GetLimiterParams on modal open). If
@@ -191,10 +196,10 @@ E2E live (deploy job, runs on iem.lan with real REAPER):
      the limiter (the existing tone generator already used by audio-pipeline tests)
    - Hold for 5 seconds, stop tone
    - Open that member's limiter modal
-   - Read the `Active:` line, parse `M:SS`, assert total seconds ≥ 5
+   - Read the activity row text, parse the "X.X sec limited" or "M min S sec limited" form, assert total seconds ≥ 5
    - Click Reset
    - Close modal, reopen
-   - Assert `Active: never`
+   - Assert "not limited yet" (or sub-second residual)
 
 ## Failure modes
 

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.148.0"
+version = "1.149.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.148.0"
+version = "1.149.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-core/src/ws.rs
+++ b/iem-mixer/crates/iem-core/src/ws.rs
@@ -99,6 +99,12 @@ pub enum ClientMsg {
     },
     /// Enable/disable limiter (FX bypass toggle) (#72)
     SetLimiterEnabled { track_index: usize, enabled: bool },
+    /// Reset the activity counter for one limiter track (#145).
+    /// Server zeros AppState.limiter_activity[track] AND writes
+    /// EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"
+    /// so meter_bridge.lua zeros its local accumulator (otherwise the
+    /// next poller cycle would re-overwrite the server's zero).
+    ResetLimiterActivity { track_index: usize },
 }
 
 /// Server → Client events (pushed via WebSocket)
@@ -186,6 +192,11 @@ pub enum ServerMsg {
         /// Normalized slider position (0-1)
         limit_norm: f32,
         enabled: bool,
+        /// Cumulative seconds the limiter has been actively reducing gain
+        /// (GR < -1 dB) since the last reset or app restart (#145).
+        /// Default 0.0 for backwards compatibility with older servers.
+        #[serde(default)]
+        active_seconds: f64,
     },
 }
 
@@ -839,12 +850,53 @@ mod tests {
             limit_db: -6.0,
             limit_norm: 0.0,
             enabled: true,
+            active_seconds: 0.0,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains("LimiterParams"));
         assert!(json.contains("PETRONELA inear"));
         assert!(json.contains("-6"));
         let back: ServerMsg = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn test_server_msg_limiter_params_active_seconds_default() {
+        // Older server may emit LimiterParams without active_seconds; new client
+        // must still deserialize it with active_seconds = 0.0.
+        let json = r#"{"event":"LimiterParams","data":{"track_index":23,"track_name":"PETRONELA inear","limit_db":-6.0,"limit_norm":0.0,"enabled":true}}"#;
+        let decoded: ServerMsg = serde_json::from_str(json).unwrap();
+        match decoded {
+            ServerMsg::LimiterParams { active_seconds, .. } => {
+                assert_eq!(active_seconds, 0.0);
+            }
+            _ => panic!("Expected LimiterParams variant"),
+        }
+    }
+
+    #[test]
+    fn test_server_msg_limiter_params_with_active_seconds() {
+        let msg = ServerMsg::LimiterParams {
+            track_index: 23,
+            track_name: "PETRONELA inear".to_string(),
+            limit_db: -6.0,
+            limit_norm: 0.0,
+            enabled: true,
+            active_seconds: 83.5,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"active_seconds\":83.5"));
+        let back: ServerMsg = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn test_client_msg_reset_limiter_activity_serialization() {
+        let msg = ClientMsg::ResetLimiterActivity { track_index: 23 };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"cmd\":\"ResetLimiterActivity\""));
+        assert!(json.contains("\"track_index\":23"));
+        let back: ClientMsg = serde_json::from_str(&json).unwrap();
         assert_eq!(msg, back);
     }
 }

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.148.0"
+version = "1.149.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/crates/iem-server/src/lib.rs
+++ b/iem-mixer/crates/iem-server/src/lib.rs
@@ -151,6 +151,11 @@ pub struct AppState {
     pub limiter_write_lock: Arc<tokio::sync::Mutex<()>>,
     /// Mutex to serialize limiter EXTSTATE reads (#72)
     pub limiter_read_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Per-inear-track cumulative active milliseconds from the limiter
+    /// (#145). Populated by the background poller from EXTSTATE
+    /// REAPERIEM_LIMITER_ACTIVITY/totals; zeroed entry-by-entry via the
+    /// ClientMsg::ResetLimiterActivity handler.
+    pub limiter_activity: Arc<tokio::sync::Mutex<std::collections::HashMap<usize, u64>>>,
 }
 
 /// Global IEM output volume state for a member
@@ -245,6 +250,7 @@ impl AppState {
             eq_read_lock: Arc::new(tokio::sync::Mutex::new(())),
             limiter_write_lock: Arc::new(tokio::sync::Mutex::new(())),
             limiter_read_lock: Arc::new(tokio::sync::Mutex::new(())),
+            limiter_activity: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 }

--- a/iem-mixer/crates/iem-server/src/poller.rs
+++ b/iem-mixer/crates/iem-server/src/poller.rs
@@ -55,6 +55,26 @@ pub fn parse_meter_bridge(text: &str) -> HashMap<usize, [f32; 2]> {
     meters
 }
 
+/// Parse limiter activity EXTSTATE response into per-track active_ms map.
+/// Input format: "23:1230;24:0;25:8470" (track_idx_1based:active_ms_u64)
+/// Skips malformed entries silently.
+pub fn parse_limiter_activity_totals(text: &str) -> HashMap<usize, u64> {
+    let mut totals = HashMap::new();
+    for entry in text.split(';') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((idx_str, ms_str)) = entry.split_once(':')
+            && let Ok(track_idx) = idx_str.parse::<usize>()
+            && let Ok(ms) = ms_str.parse::<u64>()
+        {
+            totals.insert(track_idx, ms);
+        }
+    }
+    totals
+}
+
 /// Discover band members from REAPER by querying tracks ending in " inear".
 /// REAPER is the source of truth for member names.
 /// Returns the list of discovered members, or empty if REAPER is unreachable.
@@ -485,6 +505,18 @@ async fn poll_reaper_and_broadcast(state: &AppState) {
                     meters = bridge_meters;
                 }
             }
+        }
+
+        // Limiter activity totals (#145) — meter_bridge.lua writes per-track
+        // cumulative active milliseconds where the limiter is reducing gain.
+        let lim_url = reaper_api::get_extstate(&reaper_url, "REAPERIEM_LIMITER_ACTIVITY", "totals");
+        if let Ok(resp) = state.http_client.get(&lim_url).send().await
+            && let Ok(text) = resp.text().await
+            && let Some(value) = text.split('\t').nth(3)
+        {
+            let totals = parse_limiter_activity_totals(value);
+            let mut guard = state.limiter_activity.lock().await;
+            *guard = totals;
         }
     }
 
@@ -1967,5 +1999,29 @@ TRACK\t23\tPETKA inear\t0\t1.000000\t0.000000\t-50\t-60\t1.000000\t0\t0\t22\t0\t
             should_broadcast,
             "Mute changes must always be broadcast (no suppression during listen)"
         );
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_parses_pairs() {
+        let text = "23:1230;24:0;25:8470";
+        let parsed = super::parse_limiter_activity_totals(text);
+        assert_eq!(parsed.get(&23), Some(&1230));
+        assert_eq!(parsed.get(&24), Some(&0));
+        assert_eq!(parsed.get(&25), Some(&8470));
+        assert_eq!(parsed.len(), 3);
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_empty_input() {
+        assert!(super::parse_limiter_activity_totals("").is_empty());
+    }
+
+    #[test]
+    fn parse_limiter_activity_totals_skips_malformed_entries() {
+        let text = "23:1230;garbage;24:not_a_number;25:9999";
+        let parsed = super::parse_limiter_activity_totals(text);
+        assert_eq!(parsed.get(&23), Some(&1230));
+        assert_eq!(parsed.get(&25), Some(&9999));
+        assert_eq!(parsed.len(), 2);
     }
 }

--- a/iem-mixer/crates/iem-server/src/poller.rs
+++ b/iem-mixer/crates/iem-server/src/poller.rs
@@ -509,6 +509,11 @@ async fn poll_reaper_and_broadcast(state: &AppState) {
 
         // Limiter activity totals (#145) — meter_bridge.lua writes per-track
         // cumulative active milliseconds where the limiter is reducing gain.
+        // Unlike the meter block above, we deliberately do NOT early-return on
+        // an empty value: meter_bridge always writes a non-empty string when
+        // at least one inear track has the limiter inserted, so an empty value
+        // legitimately means "no tracks have a limiter right now" and the
+        // HashMap should be cleared to reflect that.
         let lim_url = reaper_api::get_extstate(&reaper_url, "REAPERIEM_LIMITER_ACTIVITY", "totals");
         if let Ok(resp) = state.http_client.get(&lim_url).send().await
             && let Ok(text) = resp.text().await

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1308,6 +1308,17 @@ async fn handle_ws(
                                 }
                                 continue;
                             }
+                            if let iem_core::ClientMsg::ResetLimiterActivity { track_index } = cmd
+                            {
+                                if owns_limiter_track(track_index) {
+                                    let state_clone = state.clone();
+                                    tokio::spawn(async move {
+                                        handle_reset_limiter_activity(&state_clone, track_index)
+                                            .await;
+                                    });
+                                }
+                                continue;
+                            }
 
                             // Handle band member alert to engineer (#125)
                             if let ClientMsg::CallEngineer = cmd {
@@ -2551,7 +2562,17 @@ pub async fn handle_get_limiter_params(
         return None;
     }
 
-    parse_limiter_params_response(track_index, value)
+    let mut reply = parse_limiter_params_response(track_index, value)?;
+    if let iem_core::ServerMsg::LimiterParams {
+        ref mut active_seconds,
+        ..
+    } = reply
+    {
+        let guard = state.limiter_activity.lock().await;
+        let ms = guard.get(&track_index).copied().unwrap_or(0);
+        *active_seconds = (ms as f64) / 1000.0;
+    }
+    Some(reply)
 }
 
 /// Parse limiter EXTSTATE response into ServerMsg
@@ -2566,6 +2587,7 @@ fn parse_limiter_params_response(track_index: usize, value: &str) -> Option<iem_
             limit_db: 0.0,
             limit_norm: 0.0,
             enabled: false,
+            active_seconds: 0.0,
         });
     }
 
@@ -2599,6 +2621,7 @@ fn parse_limiter_params_response(track_index: usize, value: &str) -> Option<iem_
         limit_db: get_field("limit="),
         limit_norm: get_field("limit_n="),
         enabled: get_field("enabled=") >= 0.5,
+        active_seconds: 0.0,
     })
 }
 
@@ -2644,6 +2667,35 @@ async fn handle_set_limiter_param(state: &AppState, track_index: usize, param: &
         } else {
             tracing::debug!(track_index, param, result, "Limiter: param set OK");
         }
+    }
+}
+
+/// Reset the activity counter for one limiter track (#145).
+/// Zeros AppState.limiter_activity[track] AND writes
+/// EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset = "<track_index>"
+/// so meter_bridge.lua zeros its local accumulator on its next tick
+/// (otherwise the next poller cycle would re-overwrite the server zero).
+pub async fn handle_reset_limiter_activity(state: &AppState, track_index: usize) {
+    {
+        let mut guard = state.limiter_activity.lock().await;
+        guard.insert(track_index, 0);
+    }
+
+    let config = state.config.read().await;
+    let reaper_url = config.reaper_url.clone();
+    drop(config);
+
+    let set_url = reaper_api::set_extstate(
+        &reaper_url,
+        "REAPERIEM_LIMITER_ACTIVITY",
+        "reset",
+        &track_index.to_string(),
+    );
+    if state.http_client.get(&set_url).send().await.is_err() {
+        tracing::error!(
+            track_index,
+            "Limiter activity reset: failed to write reset EXTSTATE"
+        );
     }
 }
 

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1238,17 +1238,15 @@ async fn handle_ws(
                             // Limiter ownership check: non-engineer members can only
                             // control the limiter on their own output track (#156).
                             let owns_limiter_track = |track_index: usize| -> bool {
-                                if is_engineer {
-                                    return true;
-                                }
                                 // Use try_read to avoid holding the lock across an await point.
-                                if let Ok(cache) = state.mixer_cache.try_read() {
-                                    cache
-                                        .output_track_indices
-                                        .get(&member_id)
-                                        .is_some_and(|&idx| idx == track_index)
-                                } else {
-                                    false // Lock contended — deny conservatively
+                                match state.mixer_cache.try_read() {
+                                    Ok(cache) => check_owns_limiter_track(
+                                        is_engineer,
+                                        &member_id,
+                                        &cache.output_track_indices,
+                                        track_index,
+                                    ),
+                                    Err(_) => false, // Lock contended — deny conservatively
                                 }
                             };
 
@@ -2676,6 +2674,23 @@ async fn handle_set_limiter_param(state: &AppState, track_index: usize, param: &
             tracing::debug!(track_index, param, result, "Limiter: param set OK");
         }
     }
+}
+
+/// Pure authorization helper for limiter commands (#145 — extracted from the
+/// WS recv-loop closure so it can be unit-tested). Engineer is always allowed;
+/// a band member is allowed only on their own output track.
+fn check_owns_limiter_track(
+    is_engineer: bool,
+    member_id: &str,
+    output_track_indices: &std::collections::HashMap<String, usize>,
+    track_index: usize,
+) -> bool {
+    if is_engineer {
+        return true;
+    }
+    output_track_indices
+        .get(member_id)
+        .is_some_and(|&idx| idx == track_index)
 }
 
 /// Reset the activity counter for one limiter track (#145).
@@ -4760,5 +4775,48 @@ TRACK\t3\tMAREK mic\t192\t1.000000\t0.000000\t-1500\t-1500\t1.000000\t3\t9\t0\t0
     #[test]
     fn test_limiter_ms_to_seconds_one_second() {
         assert_eq!(limiter_ms_to_seconds(1000), 1.0);
+    }
+
+    // ================================================================
+    // Limiter authorization (#145 / #156)
+    // ================================================================
+
+    #[test]
+    fn test_check_owns_limiter_track_engineer_any_track() {
+        let indices = std::collections::HashMap::new();
+        // Engineer is allowed on any track, even ones not in the index map.
+        assert!(check_owns_limiter_track(true, "engineer", &indices, 1));
+        assert!(check_owns_limiter_track(true, "engineer", &indices, 99));
+    }
+
+    #[test]
+    fn test_check_owns_limiter_track_member_own_track() {
+        let mut indices = std::collections::HashMap::new();
+        indices.insert("petronela".to_string(), 23);
+        assert!(check_owns_limiter_track(false, "petronela", &indices, 23));
+    }
+
+    #[test]
+    fn test_check_owns_limiter_track_member_other_track() {
+        let mut indices = std::collections::HashMap::new();
+        indices.insert("petronela".to_string(), 23);
+        indices.insert("stevo".to_string(), 24);
+        // Petronela (track 23) must NOT be allowed on Stevo's track (24).
+        assert!(!check_owns_limiter_track(false, "petronela", &indices, 24));
+    }
+
+    #[test]
+    fn test_check_owns_limiter_track_member_unknown_id() {
+        let indices = std::collections::HashMap::new();
+        // Unknown member id with empty indices → denied.
+        assert!(!check_owns_limiter_track(false, "nobody", &indices, 23));
+    }
+
+    #[test]
+    fn test_check_owns_limiter_track_engineer_trumps_missing_entry() {
+        // Engineer id isn't in the output_track_indices map, but is_engineer=true
+        // overrides that check.
+        let indices = std::collections::HashMap::new();
+        assert!(check_owns_limiter_track(true, "engineer", &indices, 32));
     }
 }

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -2572,9 +2572,15 @@ pub async fn handle_get_limiter_params(
     {
         let guard = state.limiter_activity.lock().await;
         let ms = guard.get(&track_index).copied().unwrap_or(0);
-        *active_seconds = (ms as f64) / 1000.0;
+        *active_seconds = limiter_ms_to_seconds(ms);
     }
     Some(reply)
+}
+
+/// Convert accumulated limiter-activity milliseconds to seconds.
+#[inline]
+fn limiter_ms_to_seconds(ms: u64) -> f64 {
+    (ms as f64) / 1000.0
 }
 
 /// Parse limiter EXTSTATE response into ServerMsg
@@ -4733,5 +4739,26 @@ TRACK\t3\tMAREK mic\t192\t1.000000\t0.000000\t-1500\t-1500\t1.000000\t3\t9\t0\t0
             logs_contain("trace-capture-bt-marker-99"),
             "expected backtrace body to appear in captured logs",
         );
+    }
+
+    // ================================================================
+    // Limiter activity ms → seconds conversion (#145)
+    // ================================================================
+
+    #[test]
+    fn test_limiter_ms_to_seconds_zero() {
+        assert_eq!(limiter_ms_to_seconds(0), 0.0);
+    }
+
+    #[test]
+    fn test_limiter_ms_to_seconds_exact() {
+        // 83_500 ms = 83.5 s; division (not multiplication or modulo)
+        let result = limiter_ms_to_seconds(83_500);
+        assert!((result - 83.5).abs() < 1e-9, "expected 83.5, got {result}");
+    }
+
+    #[test]
+    fn test_limiter_ms_to_seconds_one_second() {
+        assert_eq!(limiter_ms_to_seconds(1000), 1.0);
     }
 }

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -2576,7 +2576,6 @@ pub async fn handle_get_limiter_params(
 }
 
 /// Convert accumulated limiter-activity milliseconds to seconds.
-#[inline]
 fn limiter_ms_to_seconds(ms: u64) -> f64 {
     (ms as f64) / 1000.0
 }

--- a/iem-mixer/crates/iem-server/src/proxy.rs
+++ b/iem-mixer/crates/iem-server/src/proxy.rs
@@ -1835,7 +1835,8 @@ async fn apply_command_to_cache(
         }
         iem_core::ClientMsg::GetLimiterParams { .. }
         | iem_core::ClientMsg::SetLimiterParam { .. }
-        | iem_core::ClientMsg::SetLimiterEnabled { .. } => {
+        | iem_core::ClientMsg::SetLimiterEnabled { .. }
+        | iem_core::ClientMsg::ResetLimiterActivity { .. } => {
             return Err("Limiter commands handled before apply_command_to_cache".to_string());
         }
     }
@@ -2139,7 +2140,8 @@ async fn apply_command_to_cache(
         }
         iem_core::ClientMsg::GetLimiterParams { .. }
         | iem_core::ClientMsg::SetLimiterParam { .. }
-        | iem_core::ClientMsg::SetLimiterEnabled { .. } => {
+        | iem_core::ClientMsg::SetLimiterEnabled { .. }
+        | iem_core::ClientMsg::ResetLimiterActivity { .. } => {
             unreachable!("Limiter commands handled before apply_command_to_cache")
         }
         iem_core::ClientMsg::SetGlobalMute { muted } => {

--- a/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+++ b/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Limiter Activity Counter — Issue #145
+ *
+ * Verifies that the per-track Active counter inside the LimiterModal
+ * accumulates time when the safety limiter is reducing gain, and that
+ * the Reset button zeros the counter (both server- and ReaScript-side).
+ *
+ * Requires REAPER on iem.lan with the modified MGA_JSLimiterST exposing
+ * slider5 (deployed by CI).  Uses the tone_generator ReaScript to drive
+ * a hot signal into the engineer's mix bus, which then exceeds the
+ * limiter ceiling (-6 dBFS by default) on the engineer's inear track.
+ */
+
+import { test, expect, Page } from "@playwright/test";
+
+const REAPER_URL = "http://iem.lan:8080";
+const TONE_GEN_ACTION = "_RS_REAPERIEM_TONE_GEN";
+
+async function loginAsEngineer(page: Page) {
+  const response = await page.request.post("/api/auth", {
+    data: { member: "engineer", pin: "1177" },
+  });
+  expect(response.status()).toBe(200);
+  const data = await response.json();
+  await page.evaluate(
+    ({ token, member, engineer }) => {
+      localStorage.setItem(
+        "iem_token",
+        JSON.stringify({ token, member, engineer }),
+      );
+    },
+    { token: data.token, member: data.member, engineer: data.engineer },
+  );
+}
+
+async function triggerToneGenerator(page: Page) {
+  // Toggles the test tone on the engineer track. First call = on, second = off.
+  await page.request.get(`${REAPER_URL}/_/${TONE_GEN_ACTION}`).catch(() => {});
+}
+
+async function readActiveText(page: Page): Promise<string> {
+  const label = page.locator(".limiter-activity-label");
+  await expect(label).toBeVisible({ timeout: 5000 });
+  return (await label.innerText()).trim();
+}
+
+function parseActiveSeconds(text: string): number {
+  // Format: "Active: never" or "Active: M:SS"
+  const stripped = text.replace(/^Active:\s*/, "").trim();
+  if (stripped === "never") return 0;
+  const match = stripped.match(/^(\d+):(\d{2})$/);
+  if (!match) {
+    throw new Error(`Unparseable active text: '${text}'`);
+  }
+  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+}
+
+test.describe("Limiter Activity Counter — Issue #145", () => {
+  const consoleMessages: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    consoleMessages.length = 0;
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        if (msg.text().includes("subscribe await failed")) return;
+        if (msg.text().includes("Push API in incognito")) return;
+        if (msg.text().includes("vapid-key fetch error")) return;
+        if (msg.text().includes("navigator.vibrate")) return;
+        if (msg.text().includes("closure invoked recursively")) return;
+        if (msg.text().includes("[vite]")) return;
+        if (msg.text().includes("favicon")) return;
+        if (msg.text().includes("integrity")) return;
+        if (msg.text().includes("WebSocket connection")) return;
+        consoleMessages.push(`[${msg.type()}] ${msg.text()}`);
+      }
+    });
+  });
+
+  test.afterEach(async () => {
+    expect(consoleMessages).toEqual([]);
+  });
+
+  test("counter accumulates while limiter is reducing gain, Reset zeros it", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    // Login + navigate to engineer's own mixer
+    await page.goto("/");
+    await loginAsEngineer(page);
+    await page.goto("/engineer");
+    await expect(page.locator(".mixer-header").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Make sure no test tone is leaking from a previous run; toggle off-then-on
+    // to ensure we start in a known state. The TONE_GEN action toggles, so we
+    // call once to whatever the current state was, wait, then trigger again to
+    // explicitly turn it ON.
+    await triggerToneGenerator(page);
+    await page.waitForTimeout(800);
+
+    // Find the LIM button on the engineer's own channel strip.
+    // ENGINEER inear is the engineer's own output bus; the modal we open is
+    // for that track.  We open the FIRST limiter button on the page, which
+    // for the engineer's mixer is their own.
+    const limitBtn = page.locator(".limiter-btn-small").first();
+    await expect(limitBtn).toBeVisible({ timeout: 10_000 });
+
+    // Reset first so we measure ONLY this test's accumulation.
+    await limitBtn.click();
+    await expect(page.locator(".limiter-modal")).toBeVisible({ timeout: 5000 });
+    const resetBtnPre = page.locator(".limiter-reset-btn");
+    await expect(resetBtnPre).toBeVisible();
+    await resetBtnPre.click();
+    // Close + reopen so we re-fetch active_seconds from the server.
+    await page.locator(".limiter-close-btn").click();
+    await expect(page.locator(".limiter-modal")).not.toBeVisible({
+      timeout: 2000,
+    });
+
+    // Now turn the tone ON (it was a no-op previously if it was already off).
+    await triggerToneGenerator(page);
+
+    // Hold the hot signal long enough for the limiter to engage and accumulate
+    // measurable active time.  meter_bridge polls per defer tick (~30 ms);
+    // 6 s of audible signal should produce well over 5 s of accumulated activity.
+    await page.waitForTimeout(6000);
+
+    // Open the modal again and read the counter
+    await limitBtn.click();
+    await expect(page.locator(".limiter-modal")).toBeVisible({ timeout: 5000 });
+    const activeText = await readActiveText(page);
+    const activeSecs = parseActiveSeconds(activeText);
+    expect(
+      activeSecs,
+      `Expected >= 5 s of limiter activity after a 6 s hot tone, got '${activeText}'`,
+    ).toBeGreaterThanOrEqual(5);
+
+    // Reset
+    const resetBtn = page.locator(".limiter-reset-btn");
+    await resetBtn.click();
+
+    // Stop the tone before the next assertion, otherwise meter_bridge will
+    // immediately accumulate again on the next tick and the counter will not
+    // remain at zero.
+    await triggerToneGenerator(page);
+    await page.waitForTimeout(800);
+
+    // Close + reopen modal to re-fetch active_seconds from the server.
+    await page.locator(".limiter-close-btn").click();
+    await expect(page.locator(".limiter-modal")).not.toBeVisible({
+      timeout: 2000,
+    });
+    await limitBtn.click();
+    await expect(page.locator(".limiter-modal")).toBeVisible({ timeout: 5000 });
+
+    const afterReset = await readActiveText(page);
+    expect(
+      parseActiveSeconds(afterReset),
+      `After Reset + tone-off + reopen, expected 'Active: never' or 'Active: 0:00'-'0:01', got '${afterReset}'`,
+    ).toBeLessThanOrEqual(1);
+
+    // Cleanly close before afterEach runs the console-error check.
+    await page.locator(".limiter-close-btn").click();
+  });
+});

--- a/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+++ b/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
@@ -14,7 +14,19 @@
 import { test, expect, Page } from "@playwright/test";
 
 const REAPER_URL = "http://iem.lan:8080";
-const TONE_GEN_ACTION = "_RS_REAPERIEM_TONE_GEN";
+
+// tone_generator.lua is registered in reaper-kb.ini with a SHA-based action ID
+// (REAPER computes it from the script path). Only this named ID fires the
+// script via HTTP. The dynamic numeric IDs written to EXTSTATE by meter_bridge
+// via reaper.AddRemoveReaScript() do NOT fire the script via the HTTP API —
+// they're an internal command registry that is separate from HTTP-addressable
+// actions. CLAUDE.md's "_RS_REAPERIEM_TONE_GEN" shorthand is wrong; the real
+// ID is the one in reaper-kb.ini.
+//
+// If tone_generator.lua's path ever changes, this hash will change — update
+// it by grepping reaper-kb.ini for "tone_generator.lua" on iem.lan.
+const TONE_GEN_ACTION_ID =
+  "_RS39188b77eebdd3fcf32cb58063b41d1e3828b057";
 
 async function loginAsEngineer(page: Page) {
   const response = await page.request.post("/api/auth", {
@@ -33,7 +45,7 @@ async function loginAsEngineer(page: Page) {
   );
 }
 
-async function setToneGenerator(page: Page, on: boolean) {
+async function setToneGenerator(page: Page, on: boolean): Promise<void> {
   // tone_generator.lua reads EXTSTATE reaperiem/tone_gen_action ("start"|"stop")
   // and acts accordingly. It is NOT a toggle — calling the action without
   // setting tone_gen_action first is a no-op that writes "ERROR:no_action".
@@ -44,10 +56,21 @@ async function setToneGenerator(page: Page, on: boolean) {
     )
     .catch(() => {});
   await page.request
-    .get(`${REAPER_URL}/_/${TONE_GEN_ACTION}`)
+    .get(`${REAPER_URL}/_/${TONE_GEN_ACTION_ID}`)
     .catch(() => {});
   // Tone insert/remove + mute toggling needs ~300 ms to stabilise.
   await page.waitForTimeout(300);
+  // Verify the script actually ran — its atexit line clears tone_gen_action.
+  const resp = await page.request.get(
+    `${REAPER_URL}/_/GET/EXTSTATE/reaperiem/tone_gen_action`,
+  );
+  const body = await resp.text();
+  const remaining = body.split("\t")[3]?.trim() || "";
+  if (remaining !== "") {
+    throw new Error(
+      `tone_generator did not run: tone_gen_action still '${remaining}'. Check action ID hash.`,
+    );
+  }
 }
 
 async function readActiveText(page: Page): Promise<string> {

--- a/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+++ b/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
@@ -33,9 +33,21 @@ async function loginAsEngineer(page: Page) {
   );
 }
 
-async function triggerToneGenerator(page: Page) {
-  // Toggles the test tone on the engineer track. First call = on, second = off.
-  await page.request.get(`${REAPER_URL}/_/${TONE_GEN_ACTION}`).catch(() => {});
+async function setToneGenerator(page: Page, on: boolean) {
+  // tone_generator.lua reads EXTSTATE reaperiem/tone_gen_action ("start"|"stop")
+  // and acts accordingly. It is NOT a toggle — calling the action without
+  // setting tone_gen_action first is a no-op that writes "ERROR:no_action".
+  const action = on ? "start" : "stop";
+  await page.request
+    .get(
+      `${REAPER_URL}/_/SET/EXTSTATE/reaperiem/tone_gen_action/${action}`,
+    )
+    .catch(() => {});
+  await page.request
+    .get(`${REAPER_URL}/_/${TONE_GEN_ACTION}`)
+    .catch(() => {});
+  // Tone insert/remove + mute toggling needs ~300 ms to stabilise.
+  await page.waitForTimeout(300);
 }
 
 async function readActiveText(page: Page): Promise<string> {
@@ -93,17 +105,14 @@ test.describe("Limiter Activity Counter — Issue #145", () => {
       timeout: 10_000,
     });
 
-    // Make sure no test tone is leaking from a previous run; toggle off-then-on
-    // to ensure we start in a known state. The TONE_GEN action toggles, so we
-    // call once to whatever the current state was, wait, then trigger again to
-    // explicitly turn it ON.
-    await triggerToneGenerator(page);
-    await page.waitForTimeout(800);
+    // Ensure tone is OFF at the start (stop is idempotent — stops whether or
+    // not a tone_generator FX is currently inserted).
+    await setToneGenerator(page, false);
 
-    // Find the LIM button on the engineer's own channel strip.
-    // ENGINEER inear is the engineer's own output bus; the modal we open is
-    // for that track.  We open the FIRST limiter button on the page, which
-    // for the engineer's mixer is their own.
+    // The LIM button on the GlobalVolumeFader opens the limiter for the
+    // logged-in member's OWN output track (ENGINEER inear when logged in
+    // as engineer). The tone_generator drops its audio on the same track,
+    // so the limiter on ENGINEER inear is the one that will engage.
     const limitBtn = page.locator(".limiter-btn-small").first();
     await expect(limitBtn).toBeVisible({ timeout: 10_000 });
 
@@ -119,8 +128,8 @@ test.describe("Limiter Activity Counter — Issue #145", () => {
       timeout: 2000,
     });
 
-    // Now turn the tone ON (it was a no-op previously if it was already off).
-    await triggerToneGenerator(page);
+    // Turn the tone ON.
+    await setToneGenerator(page, true);
 
     // Hold the hot signal long enough for the limiter to engage and accumulate
     // measurable active time.  meter_bridge polls per defer tick (~30 ms);
@@ -144,8 +153,7 @@ test.describe("Limiter Activity Counter — Issue #145", () => {
     // Stop the tone before the next assertion, otherwise meter_bridge will
     // immediately accumulate again on the next tick and the counter will not
     // remain at zero.
-    await triggerToneGenerator(page);
-    await page.waitForTimeout(800);
+    await setToneGenerator(page, false);
 
     // Close + reopen modal to re-fetch active_seconds from the server.
     await page.locator(".limiter-close-btn").click();

--- a/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
+++ b/iem-mixer/e2e/tests/live/limiter-activity.spec.ts
@@ -80,14 +80,17 @@ async function readActiveText(page: Page): Promise<string> {
 }
 
 function parseActiveSeconds(text: string): number {
-  // Format: "Active: never" or "Active: M:SS"
-  const stripped = text.replace(/^Active:\s*/, "").trim();
-  if (stripped === "never") return 0;
-  const match = stripped.match(/^(\d+):(\d{2})$/);
-  if (!match) {
-    throw new Error(`Unparseable active text: '${text}'`);
-  }
-  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+  // format_active() output:
+  //   "not limited yet"              → 0
+  //   "21.3 sec limited"             → 21.3
+  //   "1 min 23 sec limited"         → 83.0
+  const t = text.trim();
+  if (t === "not limited yet") return 0;
+  const secsOnly = t.match(/^(\d+(?:\.\d+)?)\s+sec\s+limited$/);
+  if (secsOnly) return parseFloat(secsOnly[1]);
+  const minSec = t.match(/^(\d+)\s+min\s+(\d+)\s+sec\s+limited$/);
+  if (minSec) return parseInt(minSec[1], 10) * 60 + parseInt(minSec[2], 10);
+  throw new Error(`Unparseable limiter-activity text: '${text}'`);
 }
 
 test.describe("Limiter Activity Counter — Issue #145", () => {
@@ -189,7 +192,7 @@ test.describe("Limiter Activity Counter — Issue #145", () => {
     const afterReset = await readActiveText(page);
     expect(
       parseActiveSeconds(afterReset),
-      `After Reset + tone-off + reopen, expected 'Active: never' or 'Active: 0:00'-'0:01', got '${afterReset}'`,
+      `After Reset + tone-off + reopen, expected 'not limited yet' or '<=1.0 sec limited', got '${afterReset}'`,
     ).toBeLessThanOrEqual(1);
 
     // Cleanly close before afterEach runs the console-error check.

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.148.0"
+version = "1.149.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/iem-ui/src/components/limiter_modal.rs
+++ b/iem-mixer/iem-ui/src/components/limiter_modal.rs
@@ -18,16 +18,28 @@ fn norm_to_db(norm: f32) -> f32 {
     if db == 0.0 { 0.0 } else { db } // eliminate -0.0
 }
 
-/// Format active seconds for display in the modal: "never" when zero,
-/// otherwise "M:SS" with seconds floored. (#145)
+/// Format active seconds for the limiter-activity row (#145).
+/// The result is a self-explanatory sentence — no separate "Active:" prefix
+/// needed — so a user who has never seen this feature understands the number.
+/// Examples:
+///   0.0  -> "not limited yet"
+///   0.4  -> "0.4 sec limited"
+///   21.3 -> "21.3 sec limited"
+///   59.9 -> "59.9 sec limited"
+///   60.0 -> "1 min 0 sec limited"
+///   83.5 -> "1 min 23 sec limited"
+///   3661.0 -> "61 min 1 sec limited"
 fn format_active(secs: f64) -> String {
     if secs <= 0.0 {
-        return "never".to_string();
+        return "not limited yet".to_string();
+    }
+    if secs < 60.0 {
+        return format!("{:.1} sec limited", secs);
     }
     let total_secs = secs.floor() as u64;
     let m = total_secs / 60;
     let s = total_secs % 60;
-    format!("{}:{:02}", m, s)
+    format!("{} min {} sec limited", m, s)
 }
 
 #[cfg(test)]
@@ -35,28 +47,29 @@ mod tests {
     use super::format_active;
 
     #[test]
-    fn format_active_zero_is_never() {
-        assert_eq!(format_active(0.0), "never");
+    fn format_active_zero_is_not_limited_yet() {
+        assert_eq!(format_active(0.0), "not limited yet");
     }
 
     #[test]
-    fn format_active_negative_is_never() {
-        assert_eq!(format_active(-1.0), "never");
+    fn format_active_negative_is_not_limited_yet() {
+        assert_eq!(format_active(-1.0), "not limited yet");
     }
 
     #[test]
-    fn format_active_under_one_minute() {
-        assert_eq!(format_active(0.5), "0:00");
-        assert_eq!(format_active(1.0), "0:01");
-        assert_eq!(format_active(59.99), "0:59");
+    fn format_active_under_one_minute_shows_decimal_seconds() {
+        assert_eq!(format_active(0.4), "0.4 sec limited");
+        assert_eq!(format_active(1.0), "1.0 sec limited");
+        assert_eq!(format_active(21.3), "21.3 sec limited");
+        assert_eq!(format_active(59.9), "59.9 sec limited");
     }
 
     #[test]
-    fn format_active_minutes() {
-        assert_eq!(format_active(60.0), "1:00");
-        assert_eq!(format_active(83.5), "1:23");
-        assert_eq!(format_active(125.0), "2:05");
-        assert_eq!(format_active(3661.0), "61:01");
+    fn format_active_minutes_no_decimal() {
+        assert_eq!(format_active(60.0), "1 min 0 sec limited");
+        assert_eq!(format_active(83.5), "1 min 23 sec limited");
+        assert_eq!(format_active(125.0), "2 min 5 sec limited");
+        assert_eq!(format_active(3661.0), "61 min 1 sec limited");
     }
 }
 
@@ -139,7 +152,6 @@ pub fn LimiterModal(
                                 </div>
                                 <div class="limiter-activity-row">
                                     <span class="limiter-activity-label">
-                                        "Active: "
                                         {move || format_active(active_seconds.get())}
                                     </span>
                                     <button

--- a/iem-mixer/iem-ui/src/components/limiter_modal.rs
+++ b/iem-mixer/iem-ui/src/components/limiter_modal.rs
@@ -18,6 +18,48 @@ fn norm_to_db(norm: f32) -> f32 {
     if db == 0.0 { 0.0 } else { db } // eliminate -0.0
 }
 
+/// Format active seconds for display in the modal: "never" when zero,
+/// otherwise "M:SS" with seconds floored. (#145)
+fn format_active(secs: f64) -> String {
+    if secs <= 0.0 {
+        return "never".to_string();
+    }
+    let total_secs = secs.floor() as u64;
+    let m = total_secs / 60;
+    let s = total_secs % 60;
+    format!("{}:{:02}", m, s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_active;
+
+    #[test]
+    fn format_active_zero_is_never() {
+        assert_eq!(format_active(0.0), "never");
+    }
+
+    #[test]
+    fn format_active_negative_is_never() {
+        assert_eq!(format_active(-1.0), "never");
+    }
+
+    #[test]
+    fn format_active_under_one_minute() {
+        assert_eq!(format_active(0.5), "0:00");
+        assert_eq!(format_active(1.0), "0:01");
+        assert_eq!(format_active(59.99), "0:59");
+    }
+
+    #[test]
+    fn format_active_minutes() {
+        assert_eq!(format_active(60.0), "1:00");
+        assert_eq!(format_active(83.5), "1:23");
+        assert_eq!(format_active(125.0), "2:05");
+        assert_eq!(format_active(3661.0), "61:01");
+    }
+}
+
 /// Limiter modal for controlling max output level on a member's output bus
 #[component]
 pub fn LimiterModal(
@@ -31,8 +73,12 @@ pub fn LimiterModal(
     enabled: ReadSignal<bool>,
     /// Whether data is loading
     loading: ReadSignal<bool>,
+    /// Cumulative seconds the limiter has actively reduced gain (#145).
+    active_seconds: ReadSignal<f64>,
     /// Callback when a parameter changes: (param_name, normalized_value)
     on_param_change: Callback<(String, f32)>,
+    /// Callback when the user clicks the Reset activity button (#145).
+    on_reset: Callback<()>,
     /// Callback when enabled state changes
     on_enabled_change: Callback<bool>,
     /// Callback to close the modal
@@ -90,6 +136,18 @@ pub fn LimiterModal(
                                             view! {}.into_any()
                                         }
                                     }}
+                                </div>
+                                <div class="limiter-activity-row">
+                                    <span class="limiter-activity-label">
+                                        "Active: "
+                                        {move || format_active(active_seconds.get())}
+                                    </span>
+                                    <button
+                                        class="limiter-reset-btn"
+                                        on:click=move |_| on_reset.run(())
+                                    >
+                                        "Reset"
+                                    </button>
                                 </div>
                             </div>
                         }

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -107,7 +107,7 @@ fn connect_websocket(
     set_limiter_limit_norm: WriteSignal<f32>,
     set_limiter_enabled: WriteSignal<bool>,
     set_limiter_loading: WriteSignal<bool>,
-    /// Limiter activity counter (#145)
+    // Limiter activity counter (#145)
     set_limiter_active_seconds: WriteSignal<f64>,
     set_alert_data: WriteSignal<Option<(String, String)>>,
     alert_data: ReadSignal<Option<(String, String)>>,

--- a/iem-mixer/iem-ui/src/pages/mixer.rs
+++ b/iem-mixer/iem-ui/src/pages/mixer.rs
@@ -107,6 +107,8 @@ fn connect_websocket(
     set_limiter_limit_norm: WriteSignal<f32>,
     set_limiter_enabled: WriteSignal<bool>,
     set_limiter_loading: WriteSignal<bool>,
+    /// Limiter activity counter (#145)
+    set_limiter_active_seconds: WriteSignal<f64>,
     set_alert_data: WriteSignal<Option<(String, String)>>,
     alert_data: ReadSignal<Option<(String, String)>>,
     set_alert_active: WriteSignal<bool>,
@@ -394,10 +396,12 @@ fn connect_websocket(
                         limit_db,
                         limit_norm,
                         enabled,
+                        active_seconds,
                     } => {
                         let _ = set_limiter_limit_db.try_set(limit_db);
                         let _ = set_limiter_limit_norm.try_set(limit_norm);
                         let _ = set_limiter_enabled.try_set(enabled);
+                        let _ = set_limiter_active_seconds.try_set(active_seconds);
                         let _ = set_limiter_loading.try_set(false);
                     }
                 }
@@ -745,6 +749,8 @@ pub fn MixerPage() -> impl IntoView {
     let (limiter_limit_norm, set_limiter_limit_norm) = signal(0.0_f32);
     let (limiter_enabled, set_limiter_enabled) = signal(true);
     let (limiter_loading, set_limiter_loading) = signal(false);
+    // Limiter activity counter (#145) — cumulative seconds since last reset.
+    let (limiter_active_seconds, set_limiter_active_seconds) = signal(0.0_f64);
 
     // Channel customization (pin/hide) — loaded from server via WS
     let (pinned_channels, set_pinned_channels) = signal(Vec::<usize>::new());
@@ -854,6 +860,7 @@ pub fn MixerPage() -> impl IntoView {
             set_limiter_limit_norm,
             set_limiter_enabled,
             set_limiter_loading,
+            set_limiter_active_seconds,
             set_alert_data,
             alert_data,
             set_alert_active,
@@ -949,6 +956,7 @@ pub fn MixerPage() -> impl IntoView {
                 set_limiter_limit_norm,
                 set_limiter_enabled,
                 set_limiter_loading,
+                set_limiter_active_seconds,
                 set_alert_data,
                 alert_data,
                 set_alert_active,
@@ -1580,6 +1588,16 @@ pub fn MixerPage() -> impl IntoView {
                             limit_norm=limiter_limit_norm
                             enabled=limiter_enabled
                             loading=limiter_loading
+                            active_seconds=limiter_active_seconds
+                            on_reset=Callback::new(move |_: ()| {
+                                if let Some((ti, _)) = limiter_open.get_untracked() {
+                                    ws_send(ws_for_lim, &iem_core::ClientMsg::ResetLimiterActivity {
+                                        track_index: ti,
+                                    });
+                                    // Optimistic local update so the user sees "never" immediately.
+                                    let _ = set_limiter_active_seconds.try_set(0.0);
+                                }
+                            })
                             on_param_change=Callback::new(move |(param, value): (String, f32)| {
                                 if let Some((ti, _)) = limiter_open.get_untracked() {
                                     // Optimistic local update (no server echo)

--- a/iem-mixer/iem-ui/style.css
+++ b/iem-mixer/iem-ui/style.css
@@ -2715,9 +2715,5 @@ body.talk-live-overlay {
 }
 
 .limiter-reset-btn:hover {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-.limiter-reset-btn:active {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--bg-secondary);
 }

--- a/iem-mixer/iem-ui/style.css
+++ b/iem-mixer/iem-ui/style.css
@@ -2699,3 +2699,25 @@ body.talk-live-overlay {
 .limiter-btn-small:active {
   background: rgba(255, 107, 107, 0.35);
 }
+
+.limiter-activity-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+.limiter-activity-label {
+  color: #ddd;
+}
+
+.limiter-reset-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.limiter-reset-btn:active {
+  background: rgba(255, 255, 255, 0.25);
+}

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.148.0"
+version = "1.149.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.148.0",
+  "version": "1.149.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",

--- a/scripts/reascripts/jsfx/MGA_JSLimiterST
+++ b/scripts/reascripts/jsfx/MGA_JSLimiterST
@@ -1,0 +1,142 @@
+// MGA JS Limiter: Limits the maximum output volume of a audio signal
+// Copyright (C) 2008  Michael Gruhn
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+desc:MGA JS Limiter (Unlinked Stereo)
+//tags: dynamics limiter stereo
+//author: LOSER
+
+slider1:0<-30,0,0.1>Threshold (dB)
+slider2:200<0,500,1>Release (ms)
+slider3:75<0,100,1>Link Stereo (%)
+slider4:-0.1<-6,0,0.1>Ceiling
+slider5:0<-30,0,0.1>GR (dB read-only)
+
+in_pin:left input
+in_pin:right input
+out_pin:left output
+out_pin:right output
+
+@init
+ext_tail_size=-1;
+ext_gr_meter = 0;
+HOLDTIME = srate/128;
+
+r1Timer = 0;
+r2Timer = HOLDTIME/2;
+
+r1TimerO = 0;
+r2TimerO = HOLDTIME/2;
+
+gr_meter=1;
+gr_meter_decay = exp(1/(1*srate));
+
+@slider
+thresh = 10^(slider1/20);
+ceiling = 10^(slider4/20);
+volume = ceiling/thresh;
+
+release = slider2/1000;
+r = exp(-3/(srate*max(release,0.05)));
+
+link = sqrt(slider3*0.01);
+
+@sample
+maxSpls=abs(spl0);
+
+(r1Timer+=1) > HOLDTIME ? (r1Timer = 0; max1Block = 0; );
+max1Block = max(max1Block,maxSpls);
+(r2Timer+=1) > HOLDTIME ? (r2Timer = 0; max2Block = 0; );
+max2Block = max(max2Block,maxSpls);
+
+envT = max(max1Block,max2Block);
+
+
+maxSplsO=abs(spl1);
+
+(r1TimerO+=1) > HOLDTIME ? (r1TimerO = 0; max1BlockO = 0; );
+max1BlockO = max(max1BlockO,maxSplsO);
+(r2TimerO+=1) > HOLDTIME ? (r2TimerO = 0; max2BlockO = 0; );
+max2BlockO = max(max2BlockO,maxSplsO);
+
+envTO = max(max1BlockO,max2BlockO);
+
+
+
+env = max(env,envO*link);
+envO = max(env*link,envO);
+
+
+env = env < envT ? envT : envT + r*(env-envT);
+
+(env > thresh) ? gain = (g_meter=(thresh / env))*volume : (g_meter=1; gain=volume;);
+
+
+envO = envO < envTO ? envTO : envTO + r*(envO-envTO);
+
+(envO > thresh) ? gainO = (g_meterO=(thresh / envO))*volume : (g_meterO=1; gainO=volume;);
+
+
+
+spl0*=gain;
+spl1*=gainO;
+
+g_meter = min(g_meter,g_meterO);
+
+g_meter < gr_meter ? gr_meter=g_meter : ( gr_meter*=gr_meter_decay; gr_meter>1?gr_meter=1; );
+
+@block
+ext_gr_meter = gr_meter > 0 ? log(gr_meter) * (20/log(10)) : -150;
+slider5 = ext_gr_meter;
+sliderchange(slider5);
+
+@gfx 0 32 // request horizontal/vertical heights (0 means dont care)
+
+  gr_meter *= exp(1/30); gr_meter>1?gr_meter=1; // decay meter here so if the audio processing stops it doesnt "stick"
+  gfx_r=1; gfx_g=gfx_b=0; gfx_a=0.8;
+  
+  meter_bot=20;
+  meter_h=min(gfx_h,32);
+  xscale=gfx_w*20/meter_bot;
+
+  gfx_y=0;
+  gfx_x=gfx_w + log10(gr_meter)*xscale;
+  gfx_rectto(gfx_w,meter_h);
+
+  gfx_r=gfx_g=gfx_b=1.0; gfx_a=0.6;
+
+  s2=sqrt(2)/2;
+  g = s2;
+  while(
+    gfx_x=gfx_w + log10(g)*xscale;
+    gfx_x >= 0 ? 
+    (
+      gfx_y=0;
+      gfx_lineto(gfx_x,meter_h,0);
+      gfx_y=meter_h-gfx_texth;
+      gfx_x+=2;
+      gfx_drawnumber(log10(g)*20,0);
+      gfx_drawchar($'d');
+      gfx_drawchar($'B');
+    );
+    g*=s2;
+    gfx_x >=0;
+  );
+  gfx_a=1;
+
+  gfx_x=0; gfx_y=meter_h/2 - gfx_texth/2;
+  gfx_drawnumber(log10(gr_meter)*20,1);
+  gfx_drawchar($'d');
+  gfx_drawchar($'B');

--- a/scripts/reascripts/meter_bridge.lua
+++ b/scripts/reascripts/meter_bridge.lua
@@ -66,6 +66,17 @@ local function linear_to_db10(val)
 end
 
 function main()
+  -- Self-reload request (#145) — CI sets this after deploying new meter_bridge.lua
+  -- so the running instance exits cleanly and the freshly-triggered instance
+  -- picks up the new code. Without this, defer-based scripts keep executing
+  -- the code they were started with even after the file on disk changes.
+  local reload_request = reaper.GetExtState(SECTION, "reload_self")
+  if reload_request == "1" then
+    reaper.SetExtState(SECTION, RUNNING_KEY, "0", false)
+    reaper.SetExtState(SECTION, "reload_self", "", false)
+    return  -- No defer call — instance exits.
+  end
+
   -- Update heartbeat for duplicate detection
   reaper.SetExtState(SECTION, "heartbeat", tostring(reaper.time_precise()), false)
 

--- a/scripts/reascripts/meter_bridge.lua
+++ b/scripts/reascripts/meter_bridge.lua
@@ -104,7 +104,6 @@ function main()
     end
   end
 
-
   -- Limiter activity polling (#145).
   -- For every track that has our JS limiter, read slider5 (GR readout in dB,
   -- written by the JSFX from ext_gr_meter via sliderchange()), accumulate
@@ -120,11 +119,16 @@ function main()
   last_tick_time = now
 
   -- Reset request handling — server writes track index here when user clicks Reset.
+  -- We remember which track_idx was just reset so the accumulation loop below
+  -- skips it for this tick (otherwise the reset could immediately be undone by
+  -- the current-tick accumulation if GR is still engaging).
+  local just_reset_idx = nil
   local reset_request = reaper.GetExtState(LIMITER_SECTION, LIMITER_RESET_KEY)
   if reset_request ~= "" then
     local reset_idx = tonumber(reset_request)
     if reset_idx then
       limiter_active_ms[reset_idx] = 0
+      just_reset_idx = reset_idx
     end
     reaper.SetExtState(LIMITER_SECTION, LIMITER_RESET_KEY, "", false)
   end
@@ -148,7 +152,12 @@ function main()
       if fx_idx >= 0 then
         local track_idx = i + 1  -- 1-based to match meter convention
         local gr_db = reaper.TrackFX_GetParam(track, fx_idx, 4)  -- slider5
-        if dt_ms > 0 and gr_db < LIMITER_GR_THRESHOLD_DB then
+        -- Skip accumulation on the just-reset track this tick so the reset
+        -- sticks cleanly (otherwise GR still active → counter jumps 0 → dt_ms).
+        if dt_ms > 0
+          and gr_db < LIMITER_GR_THRESHOLD_DB
+          and track_idx ~= just_reset_idx
+        then
           limiter_active_ms[track_idx] = (limiter_active_ms[track_idx] or 0) + dt_ms
         end
         local total = limiter_active_ms[track_idx] or 0

--- a/scripts/reascripts/meter_bridge.lua
+++ b/scripts/reascripts/meter_bridge.lua
@@ -21,6 +21,22 @@ local KEY = "peaks"
 local FLOOR = -1500
 local RUNNING_KEY = "bridge_running"
 
+-- Limiter activity tracking (#145)
+-- Per-inear-track cumulative active milliseconds where GR < -1.0 dB.
+-- Resets only when EXTSTATE REAPERIEM_LIMITER_ACTIVITY/reset is set to that
+-- track index (the iem-mixer server writes this in response to the user
+-- clicking Reset in the LimiterModal).
+local LIMITER_SECTION = "REAPERIEM_LIMITER_ACTIVITY"
+local LIMITER_TOTALS_KEY = "totals"
+local LIMITER_RESET_KEY = "reset"
+local LIMITER_GR_THRESHOLD_DB = -1.0  -- counts as "active" when slider5 < this
+local LIMITER_FX_NAME_PATTERN = "MGA_JSLimiter"
+
+-- Per-track active_ms accumulator: map<track_index_1based, integer_ms>
+local limiter_active_ms = {}
+-- Tick timestamp tracking (so we attribute exact wall delta, not fixed assumed dt)
+local last_tick_time = nil
+
 -- Prevent duplicate instances
 local already_running = reaper.GetExtState(SECTION, RUNNING_KEY)
 if already_running == "1" then
@@ -71,6 +87,57 @@ function main()
       parts[#parts + 1] = track_idx .. ":" .. l_db10 .. "," .. r_db10
     end
   end
+
+
+  -- Limiter activity polling (#145).
+  -- For every track that has our JS limiter, read slider5 (GR readout in dB,
+  -- written by the JSFX from ext_gr_meter via sliderchange()), accumulate
+  -- elapsed wall time into limiter_active_ms whenever slider5 < threshold.
+  local now = reaper.time_precise()
+  local dt_ms = 0
+  if last_tick_time then
+    dt_ms = math.floor((now - last_tick_time) * 1000.0 + 0.5)
+    -- Clamp huge deltas (defer pause, REAPER backgrounded) so a 30 s pause
+    -- doesn't show up as 30 s of limiter activity.
+    if dt_ms > 250 then dt_ms = 0 end
+  end
+  last_tick_time = now
+
+  -- Reset request handling — server writes track index here when user clicks Reset.
+  local reset_request = reaper.GetExtState(LIMITER_SECTION, LIMITER_RESET_KEY)
+  if reset_request ~= "" then
+    local reset_idx = tonumber(reset_request)
+    if reset_idx then
+      limiter_active_ms[reset_idx] = 0
+    end
+    reaper.SetExtState(LIMITER_SECTION, LIMITER_RESET_KEY, "", false)
+  end
+
+  local lim_parts = {}
+  for i = 0, track_count - 1 do
+    local track = reaper.GetTrack(0, i)
+    if track then
+      local fx_count = reaper.TrackFX_GetCount(track)
+      local fx_idx = -1
+      for f = 0, fx_count - 1 do
+        local _, fx_name = reaper.TrackFX_GetFXName(track, f)
+        if fx_name and fx_name:find(LIMITER_FX_NAME_PATTERN, 1, true) then
+          fx_idx = f
+          break
+        end
+      end
+      if fx_idx >= 0 then
+        local track_idx = i + 1  -- 1-based to match meter convention
+        local gr_db = reaper.TrackFX_GetParam(track, fx_idx, 4)  -- slider5
+        if dt_ms > 0 and gr_db < LIMITER_GR_THRESHOLD_DB then
+          limiter_active_ms[track_idx] = (limiter_active_ms[track_idx] or 0) + dt_ms
+        end
+        local total = limiter_active_ms[track_idx] or 0
+        lim_parts[#lim_parts + 1] = track_idx .. ":" .. total
+      end
+    end
+  end
+  reaper.SetExtState(LIMITER_SECTION, LIMITER_TOTALS_KEY, table.concat(lim_parts, ";"), false)
 
   reaper.SetExtState(SECTION, KEY, table.concat(parts, ";"), false)
 

--- a/scripts/reascripts/meter_bridge.lua
+++ b/scripts/reascripts/meter_bridge.lua
@@ -30,7 +30,12 @@ local LIMITER_SECTION = "REAPERIEM_LIMITER_ACTIVITY"
 local LIMITER_TOTALS_KEY = "totals"
 local LIMITER_RESET_KEY = "reset"
 local LIMITER_GR_THRESHOLD_DB = -1.0  -- counts as "active" when slider5 < this
-local LIMITER_FX_NAME_PATTERN = "MGA_JSLimiter"
+-- setup_output_limiter.lua renames the MGA_JSLimiter FX to "LIMITER" via
+-- TrackFX_SetNamedConfigParm("renamed_name", "LIMITER"). TrackFX_GetFXName
+-- returns the renamed display name, so we match on "LIMITER". We also accept
+-- "MGA_JSLimiter" as a fallback in case a rename didn't stick.
+local LIMITER_DISPLAY_NAME = "LIMITER"
+local LIMITER_FALLBACK_PATTERN = "MGA_JSLimiter"
 
 -- Per-track active_ms accumulator: map<track_index_1based, integer_ms>
 local limiter_active_ms = {}
@@ -132,7 +137,10 @@ function main()
       local fx_idx = -1
       for f = 0, fx_count - 1 do
         local _, fx_name = reaper.TrackFX_GetFXName(track, f)
-        if fx_name and fx_name:find(LIMITER_FX_NAME_PATTERN, 1, true) then
+        if fx_name
+          and (fx_name:find(LIMITER_DISPLAY_NAME, 1, true)
+            or fx_name:find(LIMITER_FALLBACK_PATTERN, 1, true))
+        then
           fx_idx = f
           break
         end


### PR DESCRIPTION
## Summary
- Adds a per-inear-track active-time counter and Reset button inside the existing LimiterModal.
- Forks `MGA_JSLimiterST` to expose its internal `gr_meter` via a read-only slider5, which `meter_bridge.lua` polls every defer tick to accumulate active milliseconds whenever GR > 1 dB.
- Server poller reads totals from a single EXTSTATE key into an in-memory `HashMap<usize, u64>` on `AppState`.
- `ServerMsg::LimiterParams` extended with `active_seconds: f64` (default 0.0 for stale-PWA backwards compat). New `ClientMsg::ResetLimiterActivity { track_index }` zeros both server HashMap and ReaScript-side accumulator (via EXTSTATE round-trip).
- Counter is visible to whoever can open the LimiterModal: member for own track, engineer for any track.
- v1.148.0 → v1.149.0.

## Debugging journey (all in dev-branch commits)
- Live CI debug revealed: meter_bridge defer loop keeps executing the code it was started with, even after the file on disk changes. Added a `REAPERIEM_METERS/reload_self` EXTSTATE flag; CI sets it after deploy so the old instance exits and a fresh one picks up new code.
- Live CI debug revealed: `setup_output_limiter.lua` renames the FX to display name "LIMITER" via `TrackFX_SetNamedConfigParm`. My pattern "MGA_JSLimiter" never matched. Changed meter_bridge to match the display name with the original as a fallback.
- Live CI debug revealed: `tone_generator.lua` is NOT a toggle — it reads `EXTSTATE reaperiem/tone_gen_action` and acts on "start"|"stop". E2E test now sets the action EXTSTATE before triggering.
- Live CI debug revealed: the dynamic numeric action IDs from `reaper.AddRemoveReaScript()` are not HTTP-addressable. Only reaper-kb.ini's SHA-based IDs fire scripts via HTTP. E2E test now uses the stable hash directly.

## Test plan
- [x] Unit: `iem-core::test_server_msg_limiter_params_active_seconds_default` — older server JSON without `active_seconds` deserializes with default 0.0
- [x] Unit: `iem-core::test_server_msg_limiter_params_with_active_seconds` — full roundtrip including the new field
- [x] Unit: `iem-core::test_client_msg_reset_limiter_activity_serialization` — ResetLimiterActivity serde roundtrip
- [x] Unit: `iem-server::poller::tests::parse_limiter_activity_totals_*` — 3 tests cover happy path, empty, and malformed input
- [x] Unit: `iem-server::proxy::tests::limiter_ms_to_seconds_*` — 3 tests cover zero, ms→s conversion, mutation testing coverage
- [x] Unit: `iem-ui::components::limiter_modal::tests::format_active_*` — 4 tests cover zero, negative, sub-minute, and minute-spanning formatting
- [x] Live E2E: `iem-mixer/e2e/tests/live/limiter-activity.spec.ts` — drives 6 s of hot tone via `tone_generator` ReaScript against real iem.lan REAPER, asserts Active counter ≥ 5 s, clicks Reset, asserts counter back to ≤ 1 s
- [x] CI: all 10 jobs green including Deploy to iem.lan and post-deploy E2E (run 24384273893)
- [x] Manual post-deploy verification: tone drove ENGINEER inear to -1 dB peak; meter_bridge totals showed `32:7378` (7.4 s) of accumulated activity; reset pathway zeroed it

🤖 Generated with [Claude Code](https://claude.com/claude-code)