### PR TITLE
test(e2e): fix eq.spec.ts MIREC race (#167 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.150.0 (2026-04-14)
+
+- **Test**: Fix `openKebabMenu` race in `eq.spec.ts` — the helper now waits for the target channel strip (e.g. MIREC) to render before iterating. Previously caused intermittent `No channel found` failures in post-deploy E2E when the Mics tab render was slightly slower than the fixed 300 ms timeout.
+
 ### v1.149.0 (2026-04-13)
 
 - **Feature**: Per-inear-track limiter activation counter (#145). Open the LIM dialog on any channel to see how long that inear's safety limiter has been actively reducing gain (e.g. "21.3 sec limited" or "1 min 23 sec limited") since the last reset, plus a Reset button to zero it. Visible to engineer (any track) and to band members on their own track.

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.149.0"
+version = "1.150.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.149.0"
+version = "1.150.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.149.0"
+version = "1.150.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/e2e/tests/live/eq.spec.ts
+++ b/iem-mixer/e2e/tests/live/eq.spec.ts
@@ -35,16 +35,28 @@ async function openKebabMenu(
   channelNameContains?: string,
 ): Promise<void> {
   if (channelNameContains) {
+    // Wait for the target channel to render — after a tab switch the channel
+    // list may not be populated yet when this helper is called, which
+    // previously caused a race: the `.channel` locator had count 0 (or only
+    // some channels) and we threw "No channel found" immediately. The CSS
+    // `:has()` selector in Playwright matches an ancestor whose descendant
+    // contains the text, so this waits on the actual element we'll iterate
+    // to rather than just "any .channel exists".
+    const needle = channelNameContains.toUpperCase();
+    await expect(
+      page
+        .locator(".channel")
+        .filter({ has: page.locator(".ch-name", { hasText: needle }) })
+        .first(),
+    ).toBeVisible({ timeout: 10_000 });
+
     const channels = page.locator(".channel");
     const count = await channels.count();
     for (let i = 0; i < count; i++) {
       const card = channels.nth(i);
       const nameEl = card.locator(".ch-name");
       const nameText = await nameEl.textContent().catch(() => "");
-      if (
-        nameText &&
-        nameText.toUpperCase().includes(channelNameContains.toUpperCase())
-      ) {
+      if (nameText && nameText.toUpperCase().includes(needle)) {
         const menuBtn = card.locator(".ch-menu-btn");
         await expect(menuBtn).toBeVisible({ timeout: 5000 });
         await menuBtn.click({ force: true });

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.149.0"
+version = "1.150.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.149.0"
+version = "1.150.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.149.0",
+  "version": "1.150.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",


### PR DESCRIPTION
## Summary
- Fixes a pre-existing race in `openKebabMenu` (helper in `eq.spec.ts`) that caused the #167 EQ-curve test to fail intermittently with `No channel found containing "MIREC" in .ch-name`.
- Discovered on main-branch post-deploy run `24394049341` after merging #145 — that run had 191/192 pass, this one failure, and `eq.spec.ts` was not touched by #145 or any recent change. The test passed on 4 consecutive dev-push runs in the same CI session, confirming the flake hypothesis.

## Root cause
`openKebabMenu` iterates `page.locator(".channel")` once without waiting for the target channel strip to render. The caller at `eq.spec.ts:1364` switches to the Mics tab and sleeps 300 ms, which is usually enough but not when the self-hosted runner is loaded.

## Fix
Added a `waitFor` on a filtered locator (`.channel:has(.ch-name:text(MIREC))`) before iterating. Max wait is 10 s, matching the helper's other timeouts.

## Version
- v1.149.0 → v1.150.0 (first commit per airuleset version-bumping rule)

## Test plan
- [x] Push run `24396037317` — all 10 jobs green including Deploy to iem.lan and post-deploy E2E (the previously-failing `eq.spec.ts:1338` now passes)
- [x] Only touches the E2E helper; no production code change
- [x] `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)