### PR TITLE
fix: 7 post-merge review findings on PR #176 (v1.154.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,14 @@ jobs:
           # can never silently pass a violation through.
           python3 scripts/test_check_disposal_safety.py
 
+      - name: Self-test the deploy config merger (atomic-write contract)
+        run: |
+          # Guards the invariants that (a) auto-generated secrets
+          # (jwt_secret, vapid_private_key) survive config refreshes and
+          # (b) writes are atomic so a crash mid-deploy can't wipe them.
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/test_merge_deployed_config.py
+
       - name: Ban unsafe signal writes inside danger zones (#153)
         run: |
           # Prevents the Leptos "reactive value has already been disposed"
@@ -691,6 +699,31 @@ jobs:
           } else {
             Write-Host "::warning::REAPER not running before deploy"
             echo "was_running=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Ensure python + pyyaml available (fail-fast BEFORE stopping app)
+        shell: powershell
+        run: |
+          # merge_deployed_config.py runs later in this job and needs
+          # pyyaml. We install it here, BEFORE the app is stopped, so a
+          # missing dependency can't strand production with no running
+          # binary. If install fails, we bail out while the old app is
+          # still serving members.
+          $ErrorActionPreference = "Stop"
+          & python --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::python is not on PATH on this self-hosted runner"
+            exit 1
+          }
+          & python -m pip install --quiet --disable-pip-version-check pyyaml
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::pip install pyyaml failed (exit $LASTEXITCODE)"
+            exit 1
+          }
+          & python -c "import yaml; print('pyyaml', yaml.__version__)"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::pyyaml import failed after install"
+            exit 1
           }
 
       - name: Stop running IEM Mixer

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ MCP server for controlling REAPER as a personal monitor (IEM) mixer for church b
 
 ## Changelog
 
+### v1.154.0 (2026-04-18)
+
+- **Fix**: ALEX kl `I_RECMON=1` — keyboard now passes audio to member IEMs during live services (was silent with RECMON=0).
+- **Fix**: ALEX kl sends use `I_SENDMODE=3` (pre-fader post-FX) so TRIM IN + ReaEQ actually affect member mixes.
+- **Fix**: ALEX kl → ENGINEER inear send is muted by default, matching the existing `create_sends_for_member` convention — no more keyboard in the engineer's solo bus.
+- **Fix**: `is_input_track` (Lua) excludes REAPER folder parents (INPUTS, MICS, TECH, OUTPUTS, BAND) via `I_FOLDERDEPTH>0` — TRIM IN / ReaEQ no longer get inserted on folders.
+- **Fix**: Deploy config merger writes atomically (tmp+`os.replace`) so a crash mid-deploy can't wipe `jwt_secret` / `vapid_private_key`.
+- **CI**: Explicit `pip install pyyaml` precheck runs BEFORE stopping the app — a missing runner dependency can't leave production offline.
+- **Test**: `alex-kl.spec.ts` restores the fader position in a `finally` block so the test doesn't walk ALEX kl toward silence across CI runs.
+
 ### v1.153.0 (2026-04-16)
 
 - **Feature**: Added ALEX kl stereo keyboard input (Dante RX 13/14) routable to all band member mixes.

--- a/iem-mixer/Cargo.toml
+++ b/iem-mixer/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [package]
 name = "iem-mixer"
-version = "1.153.0"
+version = "1.154.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "In-ear monitor mixing system for REAPER"

--- a/iem-mixer/config/config.production.yaml
+++ b/iem-mixer/config/config.production.yaml
@@ -106,7 +106,10 @@ inputs:
     dante_input: 13
     default_level_db: 0.0
     category: mics
-    stereo_pair: "alex kl"
+    # Intentionally no `stereo_pair`: this entry represents ALEX kl already
+    # merged as a single stereo channel (the "kl" suffix needs explicit
+    # `category` because categorize_track() can't derive it from the name).
+    # `stereo_pair` is only meaningful on " L"/" R" entries (see input_tracks.yaml).
 
   - name: "PATRIKA mic"
     dante_input: 11

--- a/iem-mixer/crates/iem-core/Cargo.toml
+++ b/iem-mixer/crates/iem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-core"
-version = "1.153.0"
+version = "1.154.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Core types and configuration for IEM mixer"

--- a/iem-mixer/crates/iem-server/Cargo.toml
+++ b/iem-mixer/crates/iem-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-server"
-version = "1.153.0"
+version = "1.154.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Axum API server for IEM mixer"

--- a/iem-mixer/e2e/tests/live/alex-kl.spec.ts
+++ b/iem-mixer/e2e/tests/live/alex-kl.spec.ts
@@ -67,63 +67,114 @@ test.describe("ALEX kl (keyboard stereo input)", () => {
     page,
     request,
   }) => {
-    await page.goto("/");
-    await loginAs(page, "stevo");
-    await page.goto("/stevo");
-    await waitForMixer(page);
+    // Find ALEX kl track index and its STEVO-inear send index directly
+    // from REAPER so restore is robust to track reordering. Capture the
+    // starting linear D_VOL so we can restore exactly what was there —
+    // restoring to unity would be wrong if a prior engineer adjustment
+    // was in place.
+    const tracksResp = await request.get("http://iem.lan:8080/_/NTRACK;TRACK");
+    const tracksText = await tracksResp.text();
+    const lines = tracksText.split("\n");
+    const findRow = (needle: string) =>
+      lines.find((l) => {
+        const parts = l.split("\t");
+        return parts[0] === "TRACK" && parts[2] === needle;
+      });
+    const alexRow = findRow("ALEX kl");
+    const stevoInearRow = findRow("STEVO inear");
+    expect(alexRow, "ALEX kl track not found in REAPER").toBeTruthy();
+    expect(stevoInearRow, "STEVO inear track not found in REAPER").toBeTruthy();
+    const alexIdx = parseInt(alexRow!.split("\t")[1], 10);
+    const stevoInearIdx = parseInt(stevoInearRow!.split("\t")[1], 10);
 
-    const micsTab = page.locator("text=Mics").first();
-    if ((await micsTab.count()) > 0) {
-      await micsTab.click();
+    // Walk ALEX kl's sends until we find the one whose destination is STEVO inear
+    let stevoSendIdx = -1;
+    let volBefore = 1.0;
+    for (let s = 0; s < 20; s++) {
+      const r = await request.get(
+        `http://iem.lan:8080/_/GET/TRACK/${alexIdx}/SEND/${s}`,
+      );
+      const line = (await r.text()).trim();
+      if (!line.startsWith("SEND")) break;
+      const p = line.split("\t");
+      if (p.length >= 7 && parseInt(p[6], 10) === stevoInearIdx) {
+        stevoSendIdx = s;
+        volBefore = parseFloat(p[4]);
+        break;
+      }
+    }
+    expect(
+      stevoSendIdx,
+      "ALEX kl → STEVO inear send not found",
+    ).toBeGreaterThanOrEqual(0);
+
+    try {
+      await page.goto("/");
+      await loginAs(page, "stevo");
+      await page.goto("/stevo");
+      await waitForMixer(page);
+
+      const micsTab = page.locator("text=Mics").first();
+      if ((await micsTab.count()) > 0) {
+        await micsTab.click();
+        await page.waitForTimeout(200);
+      }
+
+      // Locate the ALEX kl channel (split as ch-name="ALEX" + ch-type="kl")
+      const alexKl = page
+        .locator(".channel")
+        .filter({ has: page.locator(".ch-name", { hasText: /^ALEX$/ }) })
+        .filter({ has: page.locator(".ch-type", { hasText: /^kl/ }) })
+        .first();
+      await expect(alexKl).toBeVisible({ timeout: 10000 });
+
+      // Read starting dB so we can assert relative change after the drag.
+      const dbLabel = alexKl.locator(".db-display");
+      const parseDb = async () => {
+        const txt = (await dbLabel.textContent()) || "0";
+        // Normalise "-∞" and "-inf" variants before parseFloat
+        if (/[\u221E]|inf/i.test(txt)) return -Infinity;
+        return parseFloat(txt.replace(/[^-\d.]/g, ""));
+      };
+      const dbStart = await parseDb();
+
+      const fader = alexKl.locator(".fader-track");
+      const box = await fader.boundingBox();
+      expect(box).not.toBeNull();
+
+      // Drag from ~70% of fader to ~30% — incremental moves are required,
+      // single-jump moves don't trigger pointer events on this component.
+      const startX = box!.x + box!.width * 0.7;
+      const endX = box!.x + box!.width * 0.3;
+      const y = box!.y + box!.height / 2;
+
+      await page.mouse.move(startX, y);
+      await page.mouse.down();
       await page.waitForTimeout(200);
+      const steps = 10;
+      for (let i = 1; i <= steps; i++) {
+        await page.mouse.move(startX + (endX - startX) * (i / steps), y);
+        await page.waitForTimeout(40);
+      }
+      await page.mouse.up();
+      await page.waitForTimeout(500);
+
+      // Verify the drag produced a measurable dB drop via the WebSocket
+      // round-trip (.db-display reflects the poller's snapshot of REAPER).
+      const dbEnd = await parseDb();
+      // Moving left on the fader lowers dB. A 40%-of-width drag must produce
+      // at least a 3 dB drop — anything less means the drag wasn't registered
+      // or the WS round-trip didn't propagate the change.
+      expect(dbEnd).toBeLessThan(dbStart - 3);
+      expect(dbEnd).toBeLessThan(0);
+    } finally {
+      // Restore send volume to its starting value so this live test doesn't
+      // leak state between runs. Without this, the fader walks toward the
+      // floor on every CI run and the dbEnd < dbStart-3 assertion becomes
+      // unsatisfiable — and band members hear Alex too quietly in real use.
+      await request.get(
+        `http://iem.lan:8080/_/SET/TRACK/${alexIdx}/SEND/${stevoSendIdx}/VOL/${volBefore}`,
+      );
     }
-
-    // Locate the ALEX kl channel (split as ch-name="ALEX" + ch-type="kl")
-    const alexKl = page
-      .locator(".channel")
-      .filter({ has: page.locator(".ch-name", { hasText: /^ALEX$/ }) })
-      .filter({ has: page.locator(".ch-type", { hasText: /^kl/ }) })
-      .first();
-    await expect(alexKl).toBeVisible({ timeout: 10000 });
-
-    // Read starting dB so we can assert relative change after the drag.
-    const dbLabel = alexKl.locator(".db-display");
-    const parseDb = async () => {
-      const txt = (await dbLabel.textContent()) || "0";
-      // Normalise "-∞" and "-inf" variants before parseFloat
-      if (/[\u221E]|inf/i.test(txt)) return -Infinity;
-      return parseFloat(txt.replace(/[^-\d.]/g, ""));
-    };
-    const dbStart = await parseDb();
-
-    const fader = alexKl.locator(".fader-track");
-    const box = await fader.boundingBox();
-    expect(box).not.toBeNull();
-
-    // Drag from ~70% of fader to ~30% — incremental moves are required,
-    // single-jump moves don't trigger pointer events on this component.
-    const startX = box!.x + box!.width * 0.7;
-    const endX = box!.x + box!.width * 0.3;
-    const y = box!.y + box!.height / 2;
-
-    await page.mouse.move(startX, y);
-    await page.mouse.down();
-    await page.waitForTimeout(200);
-    const steps = 10;
-    for (let i = 1; i <= steps; i++) {
-      await page.mouse.move(startX + (endX - startX) * (i / steps), y);
-      await page.waitForTimeout(40);
-    }
-    await page.mouse.up();
-    await page.waitForTimeout(500);
-
-    // Verify the drag produced a measurable dB drop via the WebSocket
-    // round-trip (.db-display reflects the poller's snapshot of REAPER).
-    const dbEnd = await parseDb();
-    // Moving left on the fader lowers dB. A 40%-of-width drag must produce
-    // at least a 3 dB drop — anything less means the drag wasn't registered
-    // or the WS round-trip didn't propagate the change.
-    expect(dbEnd).toBeLessThan(dbStart - 3);
-    expect(dbEnd).toBeLessThan(0);
   });
 });

--- a/iem-mixer/iem-ui/Cargo.toml
+++ b/iem-mixer/iem-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-ui"
-version = "1.153.0"
+version = "1.154.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "Leptos WASM frontend for IEM mixer"

--- a/iem-mixer/src-tauri/Cargo.toml
+++ b/iem-mixer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iem-mixer-app"
-version = "1.153.0"
+version = "1.154.0"
 edition = "2024"
 authors = ["REAPER IEM Team"]
 description = "IEM Mixer desktop application with Tauri 2"

--- a/iem-mixer/src-tauri/tauri.conf.json
+++ b/iem-mixer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.0.0/crates/tauri-utils/schema.json",
   "productName": "IEM Mixer",
-  "version": "1.153.0",
+  "version": "1.154.0",
   "identifier": "com.reaperiem.mixer",
   "build": {
     "frontendDist": "../iem-ui/dist",

--- a/scripts/merge_deployed_config.py
+++ b/scripts/merge_deployed_config.py
@@ -21,6 +21,7 @@ Exit codes:
   0 on success, 1 on any error.
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -67,7 +68,15 @@ def merge(src_path: Path, dest_path: Path) -> str:
     if not updated:
         return "No changes: inputs/members/dante_outputs already match source"
 
-    with dest_path.open("w", encoding="utf-8") as f:
+    # Atomic write: dump to a sibling .tmp file and os.replace() onto the
+    # destination. If the process is killed mid-write (CI cancel, runner
+    # reboot, disk full), the destination is either the old valid file or
+    # the new valid file — never a truncated intermediate state. This
+    # matters because dest_path holds auto-generated secrets (jwt_secret,
+    # vapid_private_key) that are NOT in the source and would be lost
+    # irrecoverably if the file were corrupted.
+    tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
         yaml.safe_dump(
             dest,
             f,
@@ -75,6 +84,9 @@ def merge(src_path: Path, dest_path: Path) -> str:
             default_flow_style=False,
             allow_unicode=True,
         )
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, dest_path)
     return f"Merged: refreshed {', '.join(updated)} (secrets preserved)"
 
 

--- a/scripts/reascripts/check_input_trim.lua
+++ b/scripts/reascripts/check_input_trim.lua
@@ -12,7 +12,12 @@ local section = "reaperiem"
 -- NOTE: `is_input_track` is inlined (not `require`d) in every setup_input_*/
 -- check_input_* script — REAPER's Lua `require` path doesn't reliably include
 -- the reaperiem script folder, so duplication is the safer option.
-local function is_input_track(name)
+local function is_input_track(track, name)
+    -- Folder parent tracks (INPUTS, MICS, TECH, OUTPUTS, BAND) have
+    -- I_FOLDERDEPTH > 0. Skip them — they're organisational buses.
+    if reaper.GetMediaTrackInfo_Value(track, "I_FOLDERDEPTH") > 0 then
+        return false
+    end
     local lower = name:lower()
     if lower:match("inear$") or lower:match("stems$") then return false end
     if name == "MASTER" or name == "TRANSLATOR" then return false end
@@ -29,7 +34,7 @@ local function check_trim()
         local track = reaper.GetTrack(0, i)
         local _, name = reaper.GetTrackName(track)
 
-        if is_input_track(name) then
+        if is_input_track(track, name) then
             local fx_count = reaper.TrackFX_GetCount(track)
             local has_trim = false
 

--- a/scripts/reascripts/setup_alex_kl.lua
+++ b/scripts/reascripts/setup_alex_kl.lua
@@ -37,6 +37,10 @@ local function find_track_by_name(name)
 end
 
 local function find_all_inear_tracks()
+    -- Include ENGINEER inear. Match the existing convention in
+    -- create_sends_for_member.lua: every member-inear-destined send
+    -- exists on all input tracks, but sends to ENGINEER are muted by
+    -- default (engineer unmutes selectively on their own cue).
     local result = {}
     local count = reaper.CountTracks(0)
     for i = 0, count - 1 do
@@ -88,8 +92,11 @@ local function setup()
     reaper.SetMediaTrackInfo_Value(alex_kl, "I_RECINPUT", STEREO_INPUT)
     -- Arm for recording so input levels are visible on meters
     reaper.SetMediaTrackInfo_Value(alex_kl, "I_RECARM", 1)
-    -- Monitor off (input monitor not needed for send pipeline)
-    reaper.SetMediaTrackInfo_Value(alex_kl, "I_RECMON", 0)
+    -- Monitor on: when transport is idle (the live IEM scenario), REAPER
+    -- only routes the hardware input through the track's signal chain
+    -- with I_RECMON=1. RECMON=0 would leave members hearing silence from
+    -- ALEX kl during services. Matches set_hw_input_mono in setup_iem_project.lua.
+    reaper.SetMediaTrackInfo_Value(alex_kl, "I_RECMON", 1)
 
     -- Step 3: Create sends to every <MEMBER> inear track.
     -- Reuse the preflight list — track pointers remain valid after inserting
@@ -103,9 +110,13 @@ local function setup()
         else
             local send_idx = reaper.CreateTrackSend(alex_kl, ie.track)
             if send_idx >= 0 then
-                -- Pre-FX (I_SENDMODE = 1 means pre-FX post-envelopes; 3 means pre-fader)
-                -- Use pre-FX post-envelopes (1) to match existing sends convention.
-                reaper.SetTrackSendInfo_Value(alex_kl, 0, send_idx, "I_SENDMODE", 1)
+                -- Pre-fader post-FX (mode 3). TRIM IN + ReaEQ are inserted
+                -- on ALEX kl by setup_input_trim / setup_input_eq; mode 3
+                -- taps the signal AFTER those FX but BEFORE the fader,
+                -- matching check_send_modes.lua's invariant for input
+                -- tracks. Mode 1 (pre-FX) would bypass trim/EQ entirely
+                -- AND trigger FAIL:N from check_send_modes.
+                reaper.SetTrackSendInfo_Value(alex_kl, 0, send_idx, "I_SENDMODE", 3)
                 -- Volume = unity (1.0)
                 reaper.SetTrackSendInfo_Value(alex_kl, 0, send_idx, "D_VOL", 1.0)
                 -- Pan = center (0.0)
@@ -114,6 +125,11 @@ local function setup()
                 reaper.SetTrackSendInfo_Value(alex_kl, 0, send_idx, "I_SRCCHAN", 0)
                 -- Dest channel = stereo 1-2 (same convention)
                 reaper.SetTrackSendInfo_Value(alex_kl, 0, send_idx, "I_DSTCHAN", 0)
+                -- Mute sends to ENGINEER by default (engineer unmutes selectively).
+                -- Matches create_sends_for_member.lua:35-38 convention.
+                if ie.name:lower():find("engineer") then
+                    reaper.SetTrackSendInfo_Value(alex_kl, 0, send_idx, "B_MUTE", 1)
+                end
                 sends_created = sends_created + 1
             end
         end

--- a/scripts/reascripts/setup_input_eq.lua
+++ b/scripts/reascripts/setup_input_eq.lua
@@ -14,7 +14,12 @@ local section = "reaperiem"
 -- NOTE: `is_input_track` is inlined (not `require`d) in every setup_input_*/
 -- check_input_* script — REAPER's Lua `require` path doesn't reliably include
 -- the reaperiem script folder, so duplication is the safer option.
-local function is_input_track(name)
+local function is_input_track(track, name)
+    -- Folder parent tracks (INPUTS, MICS, TECH, OUTPUTS, BAND) have
+    -- I_FOLDERDEPTH > 0. Skip them — they're organisational buses.
+    if reaper.GetMediaTrackInfo_Value(track, "I_FOLDERDEPTH") > 0 then
+        return false
+    end
     local lower = name:lower()
     if lower:match("inear$") or lower:match("stems$") then return false end
     if name == "MASTER" or name == "TRANSLATOR" then return false end
@@ -22,9 +27,14 @@ local function is_input_track(name)
     return true
 end
 
-local function needs_eq(name)
+local function needs_eq(track, name)
+    -- Folder parents are excluded (see is_input_track) — inear/stems are
+    -- leaf tracks so they pass the folder check automatically.
+    if reaper.GetMediaTrackInfo_Value(track, "I_FOLDERDEPTH") > 0 then
+        return false
+    end
     local lower = name:lower()
-    return is_input_track(name) or lower:match("inear$") or lower:match("stems$")
+    return is_input_track(track, name) or lower:match("inear$") or lower:match("stems$")
 end
 
 local function is_reaeq(fx_name)
@@ -77,7 +87,7 @@ local function setup_eq()
         local track = reaper.GetTrack(0, i)
         local _, name = reaper.GetTrackName(track)
 
-        if needs_eq(name) then
+        if needs_eq(track, name) then
             -- Clean up any duplicate ReaEQ instances first
             remove_duplicate_reaeq(track)
 

--- a/scripts/reascripts/setup_input_trim.lua
+++ b/scripts/reascripts/setup_input_trim.lua
@@ -20,7 +20,14 @@ local section = "reaperiem"
 -- include the reaperiem script folder reliably, and deploying a shared
 -- library file would require patching package.path at runtime for every
 -- script. Keeping the ~5 lines duplicated is simpler than the alternative.
-local function is_input_track(name)
+local function is_input_track(track, name)
+    -- Folder parent tracks (INPUTS, MICS, TECH, OUTPUTS, BAND) have
+    -- I_FOLDERDEPTH > 0. Skip them — they're organisational buses and
+    -- inserting TRIM IN / ReaEQ on them would double-process audio
+    -- if routing is ever reconfigured.
+    if reaper.GetMediaTrackInfo_Value(track, "I_FOLDERDEPTH") > 0 then
+        return false
+    end
     local lower = name:lower()
     if lower:match("inear$") or lower:match("stems$") then return false end
     if name == "MASTER" or name == "TRANSLATOR" then return false end
@@ -50,7 +57,7 @@ local function setup_trim()
         local track = reaper.GetTrack(0, i)
         local _, name = reaper.GetTrackName(track)
 
-        if is_input_track(name) then
+        if is_input_track(track, name) then
             if has_trim_at_pos0(track) then
                 skipped = skipped + 1
                 table.insert(skipped_names, name)

--- a/scripts/test_merge_deployed_config.py
+++ b/scripts/test_merge_deployed_config.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Unit tests for `scripts/merge_deployed_config.py`.
+
+Run: python3 scripts/test_merge_deployed_config.py
+
+The tests cover the two invariants that matter in production:
+
+1. Secrets (jwt_secret, vapid_private_key, etc.) in the deployed config
+   are never lost when OVERWRITE_KEYS (inputs/members/dante_outputs) are
+   refreshed from source.
+2. The write is atomic — a .tmp sibling is used and os.replace() finishes
+   the transaction, so a crash mid-write leaves either the old or the new
+   file, never a truncated one.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import traceback
+
+import yaml
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import merge_deployed_config as mdc  # noqa: E402
+
+
+def _write(path: pathlib.Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def test_fresh_deploy_copies_source_verbatim() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = pathlib.Path(tmp)
+        src = tmp_path / "src.yaml"
+        dest = tmp_path / "dest.yaml"
+        _write(src, {"inputs": [{"name": "FOO", "dante_input": 1}], "port": 80})
+        # dest does not exist yet — fresh install path
+        summary = mdc.merge(src, dest)
+        assert dest.exists(), "dest should exist after fresh deploy"
+        assert "Fresh deploy" in summary, summary
+        loaded = yaml.safe_load(dest.read_text(encoding="utf-8"))
+        assert loaded["port"] == 80
+        assert loaded["inputs"][0]["name"] == "FOO"
+
+
+def test_merge_preserves_secrets() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = pathlib.Path(tmp)
+        src = tmp_path / "src.yaml"
+        dest = tmp_path / "dest.yaml"
+        _write(src, {"inputs": [{"name": "NEW", "dante_input": 1}]})
+        _write(
+            dest,
+            {
+                "inputs": [{"name": "OLD", "dante_input": 1}],
+                "jwt_secret": "auto-keep-me",
+                "vapid_private_key": "keep-this-too",
+                "port": 80,
+            },
+        )
+        mdc.merge(src, dest)
+        loaded = yaml.safe_load(dest.read_text(encoding="utf-8"))
+        assert loaded["inputs"][0]["name"] == "NEW", "inputs should be refreshed"
+        assert loaded["jwt_secret"] == "auto-keep-me", "jwt_secret must survive"
+        assert loaded["vapid_private_key"] == "keep-this-too"
+        assert loaded["port"] == 80
+
+
+def test_merge_noop_when_keys_match() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = pathlib.Path(tmp)
+        src = tmp_path / "src.yaml"
+        dest = tmp_path / "dest.yaml"
+        shared = {"inputs": [{"name": "SAME", "dante_input": 1}]}
+        _write(src, shared)
+        _write(dest, {**shared, "jwt_secret": "x"})
+        summary = mdc.merge(src, dest)
+        assert "No changes" in summary, summary
+
+
+def test_atomic_write_leaves_no_tmp_file() -> None:
+    """After a successful merge, the .tmp sibling must not exist."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = pathlib.Path(tmp)
+        src = tmp_path / "src.yaml"
+        dest = tmp_path / "dest.yaml"
+        _write(src, {"inputs": [{"name": "NEW", "dante_input": 1}]})
+        _write(
+            dest,
+            {"inputs": [{"name": "OLD", "dante_input": 1}], "jwt_secret": "x"},
+        )
+        mdc.merge(src, dest)
+        tmp_sibling = dest.with_suffix(dest.suffix + ".tmp")
+        assert not tmp_sibling.exists(), (
+            f"temporary file {tmp_sibling} should not exist after successful merge"
+        )
+        # Dest must be valid YAML
+        loaded = yaml.safe_load(dest.read_text(encoding="utf-8"))
+        assert loaded["jwt_secret"] == "x"
+
+
+def test_crash_before_replace_leaves_original_intact(monkeypatch=None) -> None:
+    """Simulate a crash after tmp is written but before os.replace(): the
+    original dest must still contain the pre-merge content unchanged."""
+    import os as real_os
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = pathlib.Path(tmp)
+        src = tmp_path / "src.yaml"
+        dest = tmp_path / "dest.yaml"
+        _write(src, {"inputs": [{"name": "NEW", "dante_input": 1}]})
+        original = {"inputs": [{"name": "OLD", "dante_input": 1}], "jwt_secret": "keep"}
+        _write(dest, original)
+
+        # Patch os.replace inside the mdc module to raise — simulates a
+        # crash right at the atomic-rename point.
+        original_replace = real_os.replace
+
+        def boom(*_args, **_kwargs):
+            raise KeyboardInterrupt("simulated crash during replace")
+
+        mdc.os.replace = boom  # type: ignore[attr-defined]
+        try:
+            try:
+                mdc.merge(src, dest)
+            except KeyboardInterrupt:
+                pass  # expected
+            # Original dest must be untouched (byte-for-byte).
+            loaded = yaml.safe_load(dest.read_text(encoding="utf-8"))
+            assert loaded == original, (
+                f"dest must be unchanged after crash; got {loaded}"
+            )
+        finally:
+            mdc.os.replace = original_replace  # type: ignore[attr-defined]
+
+
+def run_all() -> int:
+    tests = [
+        test_fresh_deploy_copies_source_verbatim,
+        test_merge_preserves_secrets,
+        test_merge_noop_when_keys_match,
+        test_atomic_write_leaves_no_tmp_file,
+        test_crash_before_replace_leaves_original_intact,
+    ]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"OK  {t.__name__}")
+        except Exception:
+            failures += 1
+            print(f"FAIL {t.__name__}")
+            traceback.print_exc()
+    if failures:
+        print(f"\n{failures}/{len(tests)} tests failed")
+        return 1
+    print(f"\nAll {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_all())


### PR DESCRIPTION
## Summary

Remote review of #176 surfaced 8 findings (7 real + 1 nit). Three were affecting live production state right now; all have been fixed in code AND live REAPER was hot-patched out of band to remove the immediate breakage.

**Live production hot-fixes (already applied, verified)**
- ALEX kl `I_RECMON`: 0 → 1 (keyboard was silent during services)
- ALEX kl → ENGINEER inear send: muted (was polluting engineer solo bus at unity)

**Code fixes in this PR**
- `setup_alex_kl.lua`: `I_RECMON=1`, `I_SENDMODE=3`, mute sends to ENGINEER by default — matches `create_sends_for_member` / `check_send_modes` conventions so the bugs can't reappear when the script is re-run
- `is_input_track` (3 Lua scripts): exclude REAPER folder parents via `I_FOLDERDEPTH>0` so TRIM IN + ReaEQ never land on INPUTS/MICS/TECH/OUTPUTS/BAND folders
- `merge_deployed_config.py`: atomic `tmp+os.replace` write — a crash mid-deploy can no longer wipe `jwt_secret` / `vapid_private_key` (irrecoverable secrets)
- CI deploy: `pip install pyyaml` precheck runs BEFORE stopping the app; a missing runner dependency can't strand production offline
- `alex-kl.spec.ts`: `try/finally` restores the fader to its starting volume so the test doesn't walk ALEX kl toward silence across CI runs
- `config.production.yaml`: drop inert `stereo_pair` field from merged ALEX kl entry (no L/R suffix means `derive_stereo_side` returns None, field was dead code)

**New tests**
- `scripts/test_merge_deployed_config.py` (5 cases): fresh deploy, secret preservation, no-op on match, no `.tmp` leak, original file intact on simulated crash — wired into the Test Integrity CI job

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `python3 scripts/test_merge_deployed_config.py` — 5/5 pass
- [x] CI green on all 9 jobs including Deploy (run 24603944361)
- [x] Post-deploy E2E: 194/194 tests pass in 8.6m
  - `alex-kl.spec.ts` "appears in the Mics tab" — ok (872ms)
  - `alex-kl.spec.ts` "dragging the ALEX kl fader changes REAPER send level" — ok (2.4s), with the new fader-restore path exercised
- [x] Production serves 1.154.0 / git f3d5f62 (verified via `/api/version` on http://10.77.9.231/)
- [x] REAPER live state verified after deploy:
  - ALEX kl `I_RECMON=1` (from `.RPP`: `REC 1 1036 1 ...`)
  - Send #9 to ENGINEER inear: mute flag=8 (muted)
  - `check_send_modes` returns OK (all ALEX kl sends in mode 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)